### PR TITLE
Allow arguments in quotes to be seen as one argument

### DIFF
--- a/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
@@ -26,9 +26,11 @@ import net.dv8tion.jda.core.hooks.ListenerAdapter;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 public class CommandListener extends ListenerAdapter {
 
@@ -37,11 +39,15 @@ public class CommandListener extends ListenerAdapter {
     private static final ExecutorService COMMAND_POOL = ThreadPoolExecutorLogged.newFixedThreadPool(5, r ->
             new Thread(COMMAND_THREADS, r, "Command Pool-" + threadCounter.incrementAndGet()), CascadeBot.LOGGER);
 
+    private static final Pattern MULTIQUOTE_REGEX = Pattern.compile("[\"'](?=[\"'])");
+
     @Override
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
 
         String message = Regex.MULTISPACE_REGEX.matcher(event.getMessage().getContentRaw()).replaceAll(" ");
+        message = MULTIQUOTE_REGEX.matcher(message).replaceAll("");
+
         GuildData guildData;
         try {
             guildData = GuildDataMapper.getGuildData(event.getGuild().getIdLong());

--- a/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
@@ -95,6 +95,41 @@ public class CommandListener extends ListenerAdapter {
         }
     }
 
+    private String[] splitArgs(String input) {
+        boolean inQuotes = false; // Whether the current position is surrounded by quotes or not
+        int splitFrom = 0; // We initially start the first split from 0 to the first space
+        var args = new ArrayList<String>();
+        for (int pos = 0; pos < input.length(); pos++) {
+            char charAtPos = input.charAt(pos);
+            if (charAtPos == ' ') {
+                int splitTo = pos;
+                // If there is a quote to close this
+                if (inQuotes && (input.substring(pos).contains("\""))) {
+                    continue;
+                }
+                if (input.charAt(pos - 1) == '"') {
+                    splitTo = pos - 1; // If we are splitting after a quote, don't include the quote in the split
+                }
+                args.add(input.substring(splitFrom, splitTo));
+                splitFrom = pos + 1; // Set the next split start to be after
+            } else if (pos == input.length() - 1) {
+                int splitTo = input.length();
+                // If the end character is a quote, we want to "split" before the quote to no include it.
+                if (input.charAt(pos) == '"') {
+                    splitTo = pos;
+                }
+                args.add(input.substring(splitFrom, splitTo));
+                // End of string so do nothing else
+            } else if (charAtPos == '"') {
+                if (!inQuotes) {
+                    splitFrom += 1; // Start the split after the first quote
+                }
+                inQuotes = !inQuotes;
+            }
+        }
+        return args.toArray(String[]::new);
+    }
+
     private void processCommands(GuildMessageReceivedEvent event, GuildData guildData, String trigger, String[] args, boolean isMention) {
         ICommandMain cmd = CascadeBot.INS.getCommandManager().getCommand(trigger, event.getAuthor(), guildData);
         if (cmd != null) {

--- a/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
@@ -63,20 +63,20 @@ public class CommandListener extends ListenerAdapter {
 
         if (message.startsWith(prefix)) {
             commandWithArgs = message.substring(prefix.length()); // Remove prefix from command
-            trigger = commandWithArgs.split(" ")[0]; // Get first string before a space
-            args = ArrayUtils.remove(commandWithArgs.split(" "), 0); // Remove the command portion of the string
         } else if (guildData.getSettings().isMentionPrefix() && message.startsWith(event.getJDA().getSelfUser().getAsMention())) {
             commandWithArgs = message.substring(event.getJDA().getSelfUser().getAsMention().length()).trim();
-            trigger = commandWithArgs.split(" ")[0];
-            args = ArrayUtils.remove(commandWithArgs.split(" "), 0);
             isMention = true;
         } else if (message.startsWith(Config.INS.getDefaultPrefix() + "prefix") && !Config.INS.getDefaultPrefix().equals(guildData.getPrefix())) {
             commandWithArgs = message.substring(Config.INS.getDefaultPrefix().length());
-            trigger = commandWithArgs.split(" ")[0];
-            args = ArrayUtils.remove(commandWithArgs.split(" "), 0);
         } else {
             return;
         }
+
+        trigger = commandWithArgs.split(" ")[0];
+        commandWithArgs = commandWithArgs.substring(trigger.length()).trim();
+        // Allow ' and " to be treated equally #quoteshavefeelingstoo
+        commandWithArgs = commandWithArgs.replace("'", "\"");
+        args = splitArgs(commandWithArgs);
 
         try {
             processCommands(event, guildData, trigger, args, isMention);

--- a/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/com/cascadebot/cascadebot/events/CommandListener.java
@@ -80,8 +80,6 @@ public class CommandListener extends ListenerAdapter {
 
         trigger = commandWithArgs.split(" ")[0];
         commandWithArgs = commandWithArgs.substring(trigger.length()).trim();
-        // Allow ' and " to be treated equally #quoteshavefeelingstoo
-        commandWithArgs = commandWithArgs.replace("'", "\"");
         args = splitArgs(commandWithArgs);
 
         try {
@@ -95,7 +93,9 @@ public class CommandListener extends ListenerAdapter {
         }
     }
 
-    private String[] splitArgs(String input) {
+    public String[] splitArgs(String input) {
+        // Allow ' and " to be treated equally #quoteshavefeelingstoo
+        input = input.replace("'", "\"");
         boolean inQuotes = false; // Whether the current position is surrounded by quotes or not
         int splitFrom = 0; // We initially start the first split from 0 to the first space
         var args = new ArrayList<String>();

--- a/src/test/java/com/cascadebot/cascadebot/events/CommandListenerTest.java
+++ b/src/test/java/com/cascadebot/cascadebot/events/CommandListenerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 CascadeBot. All rights reserved.
+ * Licensed under the MIT license.
+ */
+
+package com.cascadebot.cascadebot.events;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandListenerTest {
+
+    private static CommandListener listener = new CommandListener();
+
+    @Test
+    void splitArgs() {
+        String input = "Hello \"world test\" this is a test\"";
+        assertArrayEquals(listener.splitArgs(input), new String[]{"Hello", "world test", "this", "is", "a", "test"});
+        input = "\" \" \" \"";
+        assertArrayEquals(listener.splitArgs(input), new String[]{" ", " "});
+        input = "Hello \"World\"";
+        assertArrayEquals(listener.splitArgs(input), new String[]{"Hello", "World"});
+
+    }
+
+}


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [trello](https://trello.com/b/gUQehy4l/bot).
 - [x] I have tested all of my changes.
 
## Added/Changed
Arguments enclosed within quotes shall now be treated as one argument
With the old system:

Input: `"hello world"`
Output: `["hello, world"]`

With my new proposed system:
Input: `"hello world"`
Output: `[hello world]`

