### PR TITLE
Move all subcommands into the parent package for easier access

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildCommand.java
@@ -10,9 +10,6 @@ import org.cascadebot.cascadebot.commandmeta.CommandContext;
 import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.commandmeta.ICommandRestricted;
 import org.cascadebot.cascadebot.commandmeta.Module;
-import org.cascadebot.cascadebot.commands.subcommands.guild.GuildFlagSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.guild.GuildLeaveSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.guild.GuildSaveSubCommand;
 import org.cascadebot.shared.SecurityLevel;
 
 import java.util.Set;

--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildFlagSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildFlagSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.guild;
+package org.cascadebot.cascadebot.commands.developer;
 
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.entities.Guild;

--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildLeaveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildLeaveSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.guild;
+package org.cascadebot.cascadebot.commands.developer;
 
 import net.dv8tion.jda.core.entities.Member;
 import org.cascadebot.cascadebot.commandmeta.CommandContext;

--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildSaveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildSaveSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.guild;
+package org.cascadebot.cascadebot.commands.developer;
 
 import net.dv8tion.jda.core.entities.Member;
 import org.cascadebot.cascadebot.commandmeta.Argument;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleCommand.java
@@ -11,9 +11,6 @@ import org.cascadebot.cascadebot.commandmeta.CommandContext;
 import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.commandmeta.ICommandMain;
 import org.cascadebot.cascadebot.commandmeta.Module;
-import org.cascadebot.cascadebot.commands.subcommands.module.ModuleDisableSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.module.ModuleEnableSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.module.ModuleListSubCommand;
 import org.cascadebot.cascadebot.permissions.CascadePermission;
 
 import java.util.Set;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleDisableSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleDisableSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.module;
+package org.cascadebot.cascadebot.commands.management;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleEnableSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleEnableSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.module;
+package org.cascadebot.cascadebot.commands.management;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleListSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleListSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.module;
+package org.cascadebot.cascadebot.commands.management;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Set;
 import net.dv8tion.jda.core.entities.Member;
@@ -14,7 +14,7 @@ import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.data.objects.Tag;
 import org.cascadebot.cascadebot.permissions.CascadePermission;
 
-public class TagEditSubCommand implements ICommandExecutable {
+public class TagCategorySubCommand implements ICommandExecutable {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
@@ -29,24 +29,24 @@ public class TagEditSubCommand implements ICommandExecutable {
             return;
         }
 
-        tag.setContent(context.getMessage(1));
-        context.getTypedMessaging().replySuccess("Updated tag `" + context.getArg(0) + "`");
+        tag.setCategory(context.getArg(1));
+        context.getTypedMessaging().replySuccess("Set tag `" + context.getArg(0) + "` category to `" + context.getArg(1) + "`");
     }
 
     @Override
     public String command() {
-        return "edit";
+        return "category";
     }
 
     @Override
     public CascadePermission getPermission() {
-        return CascadePermission.of("Tag edit sub command", "tag.edit", false);
+        return CascadePermission.of("Tag category sub command", "tag.category", false);
     }
 
     @Override
     public Set<Argument> getUndefinedArguments() {
         return Set.of(Argument.of("tag", null, ArgumentType.REQUIRED,
-                Set.of(Argument.of("content", "Edits the specified tag", ArgumentType.REQUIRED))));
+                Set.of(Argument.of("category", "Sets the category for the tag to go into", ArgumentType.REQUIRED))));
     }
 
     @Override

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
@@ -13,13 +13,6 @@ import org.cascadebot.cascadebot.commandmeta.CommandContext;
 import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.commandmeta.ICommandMain;
 import org.cascadebot.cascadebot.commandmeta.Module;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagCategorySubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagCreateSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagDeleteSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagEditSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagListSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagPlaceholdersSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.tag.TagRawSubCommand;
 import org.cascadebot.cascadebot.data.objects.Tag;
 import org.cascadebot.cascadebot.permissions.CascadePermission;
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
@@ -1,11 +1,9 @@
 /*
-
  * Copyright (c) 2019 CascadeBot. All rights reserved.
  * Licensed under the MIT license.
-
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Set;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
@@ -1,11 +1,9 @@
 /*
-
  * Copyright (c) 2019 CascadeBot. All rights reserved.
  * Licensed under the MIT license.
-
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Set;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Set;
 import net.dv8tion.jda.core.entities.Member;
@@ -14,7 +14,7 @@ import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.data.objects.Tag;
 import org.cascadebot.cascadebot.permissions.CascadePermission;
 
-public class TagCategorySubCommand implements ICommandExecutable {
+public class TagEditSubCommand implements ICommandExecutable {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
@@ -29,24 +29,24 @@ public class TagCategorySubCommand implements ICommandExecutable {
             return;
         }
 
-        tag.setCategory(context.getArg(1));
-        context.getTypedMessaging().replySuccess("Set tag `" + context.getArg(0) + "` category to `" + context.getArg(1) + "`");
+        tag.setContent(context.getMessage(1));
+        context.getTypedMessaging().replySuccess("Updated tag `" + context.getArg(0) + "`");
     }
 
     @Override
     public String command() {
-        return "category";
+        return "edit";
     }
 
     @Override
     public CascadePermission getPermission() {
-        return CascadePermission.of("Tag category sub command", "tag.category", false);
+        return CascadePermission.of("Tag edit sub command", "tag.edit", false);
     }
 
     @Override
     public Set<Argument> getUndefinedArguments() {
         return Set.of(Argument.of("tag", null, ArgumentType.REQUIRED,
-                Set.of(Argument.of("category", "Sets the category for the tag to go into", ArgumentType.REQUIRED))));
+                Set.of(Argument.of("content", "Edits the specified tag", ArgumentType.REQUIRED))));
     }
 
     @Override

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagListSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagListSubCommand.java
@@ -1,11 +1,9 @@
 /*
-
  * Copyright (c) 2019 CascadeBot. All rights reserved.
  * Licensed under the MIT license.
-
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Map;
 import net.dv8tion.jda.core.entities.Member;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagPlaceholdersSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagPlaceholdersSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.tag;
+package org.cascadebot.cascadebot.commands.management;
 
 import java.util.Set;
 import net.dv8tion.jda.core.EmbedBuilder;

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/QueueCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/QueueCommand.java
@@ -13,8 +13,6 @@ import org.cascadebot.cascadebot.commandmeta.CommandContext;
 import org.cascadebot.cascadebot.commandmeta.ICommandExecutable;
 import org.cascadebot.cascadebot.commandmeta.ICommandMain;
 import org.cascadebot.cascadebot.commandmeta.Module;
-import org.cascadebot.cascadebot.commands.subcommands.queue.QueueLoadSubCommand;
-import org.cascadebot.cascadebot.commands.subcommands.queue.QueueSaveSubCommand;
 import org.cascadebot.cascadebot.messaging.MessagingObjects;
 import org.cascadebot.cascadebot.music.CascadePlayer;
 import org.cascadebot.cascadebot.permissions.CascadePermission;

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/QueueLoadSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/QueueLoadSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.queue;
+package org.cascadebot.cascadebot.commands.music;
 
 import net.dv8tion.jda.core.entities.Member;
 import org.cascadebot.cascadebot.UnicodeConstants;

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/QueueSaveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/QueueSaveSubCommand.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package org.cascadebot.cascadebot.commands.subcommands.queue;
+package org.cascadebot.cascadebot.commands.music;
 
 import net.dv8tion.jda.core.entities.Member;
 import org.apache.commons.lang3.EnumUtils;


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
Moved all of the sub commands from the `subcommand` package into their respective category packages. This makes it easier to find and maintain these commands.

## Feature
If this is a new feature, why should we add it to the bot.
