### PR TITLE
Updated semantic colors

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/Constants.java
+++ b/src/main/java/org/cascadebot/cascadebot/Constants.java
@@ -8,7 +8,7 @@ package org.cascadebot.cascadebot;
 import lombok.experimental.UtilityClass;
 import org.cascadebot.shared.SharedConstants;
 
-import java.awt.*;
+import java.awt.Color;
 
 @UtilityClass
 public class Constants {

--- a/src/main/java/org/cascadebot/cascadebot/Constants.java
+++ b/src/main/java/org/cascadebot/cascadebot/Constants.java
@@ -17,10 +17,10 @@ public class Constants {
     public static String serverInvite = "https://discord.gg/P23GZFB";
 
     // Semantic colors used for embeds
-    public static final Color COLOR_SUCCESS = new Color(132, 214, 162);
-    public static final Color COLOR_INFO = new Color(152, 159, 255);
-    public static final Color COLOR_WARNING = new Color(255, 187, 95);
-    public static final Color COLOR_DANGER = new Color(16741492);
+    public static final Color COLOR_SUCCESS = new Color(132, 214, 162); // #84D6A2
+    public static final Color COLOR_INFO = new Color(152, 159, 255); // #989FFF
+    public static final Color COLOR_WARNING = new Color(255, 187, 95); // #FFBB5F
+    public static final Color COLOR_DANGER = new Color(16741492); // #FF7474
     public static final Color COLOR_MODERATION = Color.WHITE;
     public static final Color COLOR_NEUTRAL = SharedConstants.CASCADE_COLOR;
 

--- a/src/main/java/org/cascadebot/cascadebot/Constants.java
+++ b/src/main/java/org/cascadebot/cascadebot/Constants.java
@@ -14,7 +14,7 @@ import java.awt.*;
 public class Constants {
 
     // Changeable constants if needed
-    public static final String serverInvite = "https://discord.gg/P23GZFB";
+    public static String serverInvite = "https://discord.gg/P23GZFB";
 
     // Semantic colors used for embeds
     public static final Color COLOR_SUCCESS = new Color(132, 214, 162);

--- a/src/main/java/org/cascadebot/cascadebot/Constants.java
+++ b/src/main/java/org/cascadebot/cascadebot/Constants.java
@@ -6,6 +6,9 @@
 package org.cascadebot.cascadebot;
 
 import lombok.experimental.UtilityClass;
+import org.cascadebot.shared.SharedConstants;
+
+import java.awt.*;
 
 @UtilityClass
 public class Constants {
@@ -13,5 +16,12 @@ public class Constants {
     // Changeable constants if needed
     public static final String serverInvite = "https://discord.gg/P23GZFB";
 
+    // Semantic colors used for embeds
+    public static final Color COLOR_SUCCESS = new Color(132, 214, 162);
+    public static final Color COLOR_INFO = new Color(152, 159, 255);
+    public static final Color COLOR_WARNING = new Color(255, 187, 95);
+    public static final Color COLOR_DANGER = new Color(16741492);
+    public static final Color COLOR_MODERATION = Color.WHITE;
+    public static final Color COLOR_NEUTRAL = SharedConstants.CASCADE_COLOR;
 
 }

--- a/src/main/java/org/cascadebot/cascadebot/messaging/MessageType.java
+++ b/src/main/java/org/cascadebot/cascadebot/messaging/MessageType.java
@@ -7,8 +7,8 @@ package org.cascadebot.cascadebot.messaging;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.cascadebot.cascadebot.Constants;
 import org.cascadebot.cascadebot.UnicodeConstants;
-import org.cascadebot.shared.SharedConstants;
 
 import java.awt.Color;
 
@@ -16,12 +16,12 @@ import java.awt.Color;
 @RequiredArgsConstructor
 public enum MessageType {
 
-    INFO(Color.CYAN, UnicodeConstants.INFORMATION),
-    SUCCESS(Color.GREEN, UnicodeConstants.TICK),
-    WARNING(Color.YELLOW, UnicodeConstants.WARNING),
-    MODERATION(Color.WHITE, UnicodeConstants.POLICE),
-    DANGER(Color.RED, UnicodeConstants.RED_CROSS),
-    NEUTRAL(SharedConstants.CASCADE_COLOR, "");
+    INFO(Constants.COLOR_INFO, UnicodeConstants.INFORMATION),
+    SUCCESS(Constants.COLOR_SUCCESS, UnicodeConstants.TICK),
+    WARNING(Constants.COLOR_WARNING, UnicodeConstants.WARNING),
+    MODERATION(Constants.COLOR_MODERATION, UnicodeConstants.POLICE),
+    DANGER(Constants.COLOR_DANGER, UnicodeConstants.RED_CROSS),
+    NEUTRAL(Constants.COLOR_NEUTRAL, "");
 
     private final Color color;
     private final String emoji;


### PR DESCRIPTION
# Pull request

 - [X] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [X] I have tested all of my changes.
 
## Added/Changed
 - added semantic colors to constants and implemented them in messageType enum
 - removed final from server invite link.

Closes #53 
