### PR TITLE
Fix: Tags ran when commands also ran

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -188,14 +188,14 @@ public class CommandListener extends ListenerAdapter {
                 }
             }
             dispatchCommand(cmd, context);
-        }
+        } else {
+            if (guildData.getSettings().isAllowTagCommands()) {
+                if (guildData.getSettings().getTags().containsKey(trigger)) {
+                    Tag tag = guildData.getSettings().getTag(trigger);
 
-        if (guildData.getSettings().isAllowTagCommands()) {
-            if (guildData.getSettings().getTags().containsKey(trigger)) {
-                Tag tag = guildData.getSettings().getTag(trigger);
-
-                context.reply(tag.formatTag(context)); //TODO perms for tags
-                CascadeBot.LOGGER.info("Tag {} executed by {} with args {}", trigger, context.getUser().getAsTag(), Arrays.toString(context.getArgs()));
+                    context.reply(tag.formatTag(context)); //TODO perms for tags
+                    CascadeBot.LOGGER.info("Tag {} executed by {} with args {}", trigger, context.getUser().getAsTag(), Arrays.toString(context.getArgs()));
+                }
             }
         }
     }


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.
 
## Added/Changed
- Before this fix, tags with the same name as a command would run after the command
- This is not expected behaviour so for example if you have a tag named `info`, our info command should run on `;info` and not the tag.
- I have changed the code to reflect this
