### PR TITLE
Fix queue hanging forever when a song playing but nothing in the queue

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commands/music/QueueCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/QueueCommand.java
@@ -32,8 +32,8 @@ public class QueueCommand implements ICommandMain {
 
         embedBuilder.setTitle("Queue");
 
-        if (player.getQueue().isEmpty() && player.getPlayer().getPlayingTrack() == null) {
-            context.getTypedMessaging().replyInfo("There are no tracks playing!");
+        if (player.getQueue().isEmpty()) {
+            context.getTypedMessaging().replyInfo("There are no tracks in the queue!");
             return;
         }
 


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
- Before the queue command would hang forever due to there being no things in the queue but something playing