### PR TITLE
Make sure cascade only responds when we can actually write

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -48,10 +48,7 @@ public class CommandListener extends ListenerAdapter {
 
     @Override
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
-        if (event.getAuthor().isBot()) {
-            return;
-        }
-        if (event.getMessage().getType() != MessageType.DEFAULT) {
+        if (event.getAuthor().isBot() || event.getMessage().getType() != MessageType.DEFAULT || !event.getChannel().canTalk()) {
             return;
         }
 


### PR DESCRIPTION
We should only respond when we can read **and** write to the channel