### PR TITLE
Hotfix for args splitter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.cascadebot</groupId>
     <artifactId>cascadebot</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
 
     <properties>
         <build.number>DEV</build.number>

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -122,7 +122,7 @@ public class CommandListener extends ListenerAdapter {
             char charAtPos = input.charAt(pos);
             if (charAtPos == ' ') {
                 // If we are in a quote or bracket scope then we want to ignore this space
-                if (quoteType != NONE && bracketType != NONE) {
+                if (quoteType != NONE || bracketType != NONE) {
                     continue;
                 }
                 int splitTo = pos;

--- a/src/test/java/org/cascadebot/cascadebot/events/CommandListenerTest.java
+++ b/src/test/java/org/cascadebot/cascadebot/events/CommandListenerTest.java
@@ -14,14 +14,30 @@ class CommandListenerTest {
     private static CommandListener listener = new CommandListener();
 
     @Test
-    void splitArgs() {
-        String input = "Hello \"world test\" this is a test\"";
-        assertArrayEquals(listener.splitArgs(input), new String[]{"Hello", "world test", "this", "is", "a", "test"});
-        input = "\" \" \" \"";
-        assertArrayEquals(listener.splitArgs(input), new String[]{" ", " "});
-        input = "Hello \"World\"";
-        assertArrayEquals(listener.splitArgs(input), new String[]{"Hello", "World"});
+    void testArgsNormal() {
+        assertArrayEquals(new String[]{"onearg"}, listener.splitArgs("onearg"));
+        assertArrayEquals(new String[]{"two", "args"}, listener.splitArgs("two args"));
+        assertArrayEquals(new String[]{"three", "single", "args"}, listener.splitArgs("three single args"));
+    }
 
+    @Test
+    void testArgsQuoted() {
+        assertArrayEquals(new String[]{"onearg"}, listener.splitArgs("\"onearg\""));
+        assertArrayEquals(new String[]{"two args"}, listener.splitArgs("\"two args\""));
+        assertArrayEquals(new String[]{"three single args"}, listener.splitArgs("\"three single args\""));
+        assertArrayEquals(new String[]{"onearg", "with", "extra"}, listener.splitArgs("\"onearg\" with extra"));
+        assertArrayEquals(new String[]{"two args", "with", "extra"}, listener.splitArgs("\"two args\" with extra"));
+    }
+
+    @Test
+    void testIgnoreQuotes() {
+        assertArrayEquals(new String[]{"hel\"lo", "\""}, listener.splitArgs("hel\"lo \""));
+    }
+
+    @Test
+    void testUnusual() {
+        assertArrayEquals(new String[]{"!eval", "CascadeBot.INS.getUser(\"Test\")"}, listener.splitArgs("!eval CascadeBot.INS.getUser(\"Test\")"));
+        assertArrayEquals(new String[]{"!eval", "CascadeBot.INS.getUser(\"Test\", \"123\")"}, listener.splitArgs("!eval CascadeBot.INS.getUser(\"Test\", \"123\")"));
     }
 
 }


### PR DESCRIPTION
## Added/Changed
 - The AND condition for the bracket and quote type was incorrect and should have been an OR condition instead. This error caused splitting to not occur properly
