### PR TITLE
Better utils for getting numbers from args

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandContext.java
+++ b/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandContext.java
@@ -129,11 +129,41 @@ public class CommandContext {
     }
 
     public boolean isArgInteger(int index) {
-        return Regex.INTEGER_REGEX.matcher(this.args[index]).matches();
+        try {
+            Integer.parseInt(args[index]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
-    public boolean isArgDecimal(int index) {
-        return Regex.DECIMAL_REGEX.matcher(this.args[index]).matches();
+    public boolean isArgLong(int index) {
+        try {
+            Long.parseLong(args[index]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    public boolean isArgFloat(int index) {
+        try {
+            // The replacement of the comma is to support languages which use a comma for the decimal point
+            Float.parseFloat(args[index].replaceAll(",", "."));
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    public boolean isArgDouble(int index) {
+        try {
+            // The replacement of the comma is to support languages which use a comma for the decimal point
+            Float.parseFloat(args[index].replaceAll(",", "."));
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     public String getArg(int index) {
@@ -144,8 +174,18 @@ public class CommandContext {
         return Integer.parseInt(this.args[index]);
     }
 
-    public Double getArgAsDouble(int index) {
-        return Double.parseDouble(StringUtils.replace(this.args[index], ",", "."));
+    public long getArgAsLong(int index) {
+        return Long.parseLong(this.args[index]);
+    }
+
+    public float getArgAsFloat(int index) {
+        // The replacement of the comma is to support languages which use a comma for the decimal point
+        return Float.parseFloat(this.args[index].replaceAll(",", "."));
+    }
+
+    public double getArgAsDouble(int index) {
+        // The replacement of the comma is to support languages which use a comma for the decimal point
+        return Double.parseDouble(this.args[index].replaceAll(",", "."));
     }
 
     /**

--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildSaveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildSaveSubCommand.java
@@ -23,7 +23,11 @@ public class GuildSaveSubCommand implements ISubCommand {
             GuildDataManager.getGuilds().asMap().forEach(GuildDataManager::replace);
             context.getTypedMessaging().replySuccess("Saved **all** guild information successfully!");
         } else {
-            GuildData guildData = GuildDataManager.getGuilds().asMap().get(Long.parseLong(context.getArg(0)));
+            if (!context.isArgLong(0)) {
+                context.getTypedMessaging().replyDanger("Please provide a valid ID!");
+                return;
+            }
+            GuildData guildData = GuildDataManager.getGuilds().asMap().get(context.getArgAsLong(0));
             if (guildData == null) {
                 context.getTypedMessaging().replyDanger("Cannot find a guild to save!");
                 return;


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
 - Made all args checking methods use the `.parseX` methods with exceptions to make sure range is respected
 - The util methods for both checking and parsing are as follows: 
   - Int
   - Long
   - Float
   - Double

Closes #158
