### PR TITLE
Add a util method to format the time properly

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/utils/FormatUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/FormatUtils.java
@@ -6,12 +6,16 @@
 package org.cascadebot.cascadebot.utils;
 
 import com.ibm.icu.text.DateFormat;
+import com.ibm.icu.text.MeasureFormat;
 import com.ibm.icu.text.SimpleDateFormat;
+import com.ibm.icu.util.Measure;
+import com.ibm.icu.util.MeasureUnit;
 import com.vdurmont.emoji.Emoji;
 import com.vdurmont.emoji.EmojiManager;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.internal.utils.Checks;
 import org.apache.commons.lang3.StringUtils;
 import org.cascadebot.cascadebot.CascadeBot;
 import org.cascadebot.cascadebot.UnicodeConstants;
@@ -193,6 +197,30 @@ public class FormatUtils {
 
     public static String formatDateTime(OffsetDateTime dateTime, Locale locale) {
         return SimpleDateFormat.getDateTimeInstance(DateFormat.RELATIVE_LONG, DateFormat.LONG, locale.getULocale()).format(new Date(dateTime.toEpochSecond() * 1000));
+    }
+
+    /**
+     * Formats a time string using the ICU library in the order hours, minutes and seconds.
+     * This only supports up to hours and down to seconds. If there are more than 24 hours, it will just be displayed as such and will not overflow.
+     * <br/><br/>
+     * The short form is like so: 1h 12m 23s.<br/>
+     * The long form is like so: 1 hour, 12 minutes, 23 seconds.
+     * <br/><br/>
+     * Both forms follow the relative locale's time formatting rules.
+     *
+     * @param millis The time to be formatted in milliseconds.
+     * @param locale The locale for the time to be formatted in.
+     * @param isShort Whether to display in short form or not.
+     * @return The formatted string
+     */
+    public static String formatTime(long millis, Locale locale, boolean isShort) {
+        Checks.notNegative(millis, "time");
+        long hours = TimeUnit.MILLISECONDS.toHours(millis);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(millis) - (hours * 60);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(millis) - (hours * 60 * 60) - (minutes * 60);
+
+        MeasureFormat format = MeasureFormat.getInstance(locale.getULocale(), (isShort ? MeasureFormat.FormatWidth.NARROW : MeasureFormat.FormatWidth.WIDE));
+        return format.formatMeasures(new Measure(hours, MeasureUnit.HOUR), new Measure(minutes, MeasureUnit.MINUTE), new Measure(seconds, MeasureUnit.SECOND));
     }
 
     @Deprecated


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
 - Added a util method that uses the ICU library to format a time from milliseconds

Will be used with #176 