### PR TITLE
Add a cancel button to the confirmation prompt

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/ShutdownCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/ShutdownCommand.java
@@ -31,6 +31,7 @@ public class ShutdownCommand implements ICommandRestricted {
                         context.getChannel(),
                         MessageType.DANGER,
                         "It looks like the bot is running in ***production*** mode, **do you _really_ want to do this?** \n If so, simply repeat the command again. This confirmation will expire in one minute!",
+                        true,
                         new ConfirmUtils.ConfirmRunnable() {
                             @Override
                             public void execute() {

--- a/src/main/java/org/cascadebot/cascadebot/commands/moderation/BanCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/moderation/BanCommand.java
@@ -57,6 +57,7 @@ public class BanCommand implements ICommandMain {
                     context.getChannel(),
                     MessageType.DANGER,
                     context.i18n("commands.ban.forcefully_ban"),
+                    true,
                     new ConfirmUtils.ConfirmRunnable() {
                         @Override
                         public void execute() {

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/QueueSaveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/QueueSaveSubCommand.java
@@ -62,7 +62,7 @@ public class QueueSaveSubCommand implements ISubCommand {
                     }
                 }
                 ConfirmUtils.confirmAction(sender.getIdLong(), "overwrite", context.getChannel(), MessageType.WARNING,
-                        context.i18n("commands.save.already_exists"), TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toMillis(10), new ConfirmUtils.ConfirmRunnable() {
+                        context.i18n("commands.save.already_exists"), TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toMillis(10), true,  new ConfirmUtils.ConfirmRunnable() {
                             @Override
                             public void execute() {
                                 context.getMusicPlayer().saveCurrentPlaylist(lambdaOwner, lambdaScope, context.getArg(0), false);

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
@@ -43,6 +43,7 @@ public class VolumeCommand implements ICommandMain {
                         context.i18n("commands.volume.extreme_volume"),
                         0,
                         TimeUnit.SECONDS.toMillis(30),
+                        true,
                         new ConfirmUtils.ConfirmRunnable() {
                             @Override
                             public void execute() {

--- a/src/main/java/org/cascadebot/cascadebot/utils/ConfirmUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/ConfirmUtils.java
@@ -60,6 +60,10 @@ public class ConfirmUtils {
                     if (runner.getIdLong() != action.userId) return;
                     action.run();
                 }));
+                group.addButton(new Button.UnicodeButton(UnicodeConstants.RED_CROSS, ((runner, channel1, message1) -> {
+                    confirmedMap.remove(actionKey, action);
+                    sentMessage.delete().queue(null, DiscordUtils.handleExpectedErrors(ErrorResponse.UNKNOWN_MESSAGE));
+                })));
                 group.addButtonsToMessage(sentMessage);
                 group.setMessage(sentMessage.getIdLong());
                 guildData.addButtonGroup(channel, sentMessage, group);


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
- Simple cancel button for any confirmation prompt

>  Forceban needs cancel reaction

From #189