### PR TITLE
Modifications to pages

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/messaging/Messaging.java
+++ b/src/main/java/org/cascadebot/cascadebot/messaging/Messaging.java
@@ -197,6 +197,15 @@ public final class Messaging {
     }
 
     public static CompletableFuture<Message> sendPagedMessage(TextChannel channel, Member owner, List<Page> pages) {
+        if (pages.size() == 0) {
+            throw new IllegalArgumentException("The number of pages cannot be zero!");
+        } else if (pages.size() == 1) {
+            CompletableFuture<Message> future = channel.sendMessage(Language.i18n(channel.getGuild().getIdLong(), "messaging.loading_page")).submit();
+            future.thenAccept(sentMessage -> {
+                pages.get(0).pageShow(sentMessage, 1, pages.size());
+            });
+            return future;
+        }
         ButtonGroup group = new ButtonGroup(owner.getIdLong(), channel.getIdLong(), channel.getGuild().getIdLong());
         group.addButton(new Button.UnicodeButton(UnicodeConstants.REWIND, (runner, textChannel, message) -> {
             PageCache.Pages pageGroup = GuildDataManager.getGuildData(textChannel.getGuild().getIdLong()).getPageCache().get(message.getIdLong());

--- a/src/main/java/org/cascadebot/cascadebot/utils/FormatUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/FormatUtils.java
@@ -96,6 +96,7 @@ public class FormatUtils {
 
     private static String getFooter(String footer, int padding, int... sizes) {
         StringBuilder sb = new StringBuilder();
+        footer = " " + footer;
         sb.append("|");
         int total = 0;
         for (int i = 0; i < sizes.length; i++) {


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
- Buttons are no longer displayed on a paged message if there is only one page
- A space is now added at the start of the footer in the table pages to line everything up

> If one page, don't have reactions

From #189 
