### PR TITLE
Fix mention prefix due to mismatch between different mentions. Fixes #212

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -8,6 +8,7 @@ package org.cascadebot.cascadebot.events;
 import io.prometheus.client.Summary;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -81,10 +82,17 @@ public class CommandListener extends ListenerAdapter {
         String trigger;
         String[] args;
 
+        boolean messagesBot = false;
+        for (Member member : event.getMessage().getMentionedMembers()) {
+            if (member.getIdLong() == event.getGuild().getSelfMember().getIdLong()) {
+                messagesBot = true;
+            }
+        }
+
         if (message.startsWith(prefix)) {
             commandWithArgs = message.substring(prefix.length()); // Remove prefix from command
-        } else if (guildData.getCoreSettings().isMentionPrefix() && message.startsWith(event.getJDA().getSelfUser().getAsMention())) {
-            commandWithArgs = message.substring(event.getJDA().getSelfUser().getAsMention().length()).trim();
+        } else if (guildData.getCoreSettings().isMentionPrefix() && messagesBot) {
+            commandWithArgs = message.substring(event.getJDA().getSelfUser().getAsMention().length() + 1).trim();
             isMention = true;
         } else if (message.startsWith(Config.INS.getDefaultPrefix() + Language.i18n(guildData.getLocale(), "commands.prefix.command")) && !Config.INS.getDefaultPrefix().equals(guildData.getCoreSettings().getPrefix())) {
             commandWithArgs = message.substring(Config.INS.getDefaultPrefix().length());

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -96,12 +96,9 @@ public class CommandListener extends ListenerAdapter {
             commandWithArgs = message.substring(prefix.length()); // Remove prefix from command
         }
         if (guildData.getCoreSettings().isMentionPrefix() && messagesBot) {
-            List<String> split = new ArrayList<>(Arrays.asList(message.split(">")));
-            String start = split.remove(0);
-            start += ">";
             // Make sure bot is mentioned at start of message
-            if (start.matches("<@!?" + event.getJDA().getSelfUser().getIdLong() + ">")) {
-                commandWithArgs = String.join(">", split).trim();
+            if (message.matches("^<@!?" + event.getJDA().getSelfUser().getIdLong() + ">.*")) {
+                commandWithArgs = message.substring(message.indexOf('>'));
                 isMention = true;
             }
         }

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -98,7 +98,7 @@ public class CommandListener extends ListenerAdapter {
         if (guildData.getCoreSettings().isMentionPrefix() && messagesBot) {
             // Make sure bot is mentioned at start of message
             if (message.matches("^<@!?" + event.getJDA().getSelfUser().getIdLong() + ">.*")) {
-                commandWithArgs = message.substring(message.indexOf('>'));
+                commandWithArgs = message.substring(message.indexOf('>') + 1).trim();
                 isMention = true;
             }
         }

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -35,13 +35,10 @@ import org.cascadebot.shared.Regex;
 import org.cascadebot.shared.utils.ThreadPoolExecutorLogged;
 import org.slf4j.MDC;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class CommandListener extends ListenerAdapter {
 
@@ -84,28 +81,14 @@ public class CommandListener extends ListenerAdapter {
         String trigger;
         String[] args;
 
-        // Check that the bot is even mentioned in the first place
-        boolean messagesBot = false;
-        for (Member member : event.getMessage().getMentionedMembers()) {
-            if (member.getIdLong() == event.getGuild().getSelfMember().getIdLong()) {
-                messagesBot = true;
-            }
-        }
-
         if (message.startsWith(prefix)) {
             commandWithArgs = message.substring(prefix.length()); // Remove prefix from command
-        }
-        if (guildData.getCoreSettings().isMentionPrefix() && messagesBot) {
-            // Make sure bot is mentioned at start of message
-            if (message.matches("^<@!?" + event.getJDA().getSelfUser().getIdLong() + ">.*")) {
-                commandWithArgs = message.substring(message.indexOf('>') + 1).trim();
-                isMention = true;
-            }
-        }
-        if (message.startsWith(Config.INS.getDefaultPrefix() + Language.i18n(guildData.getLocale(), "commands.prefix.command")) && !Config.INS.getDefaultPrefix().equals(guildData.getCoreSettings().getPrefix())) {
+        } else if (guildData.getCoreSettings().isMentionPrefix() && message.matches("^<@!?" + event.getJDA().getSelfUser().getId() + ">.*")) {
+            commandWithArgs = message.substring(message.indexOf('>') + 1).trim();
+            isMention = true;
+        } else if (message.startsWith(Config.INS.getDefaultPrefix() + Language.i18n(guildData.getLocale(), "commands.prefix.command")) && !Config.INS.getDefaultPrefix().equals(guildData.getCoreSettings().getPrefix())) {
             commandWithArgs = message.substring(Config.INS.getDefaultPrefix().length());
-        }
-        if (commandWithArgs == null) {
+        } else {
             return;
         }
 


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
Fixed mention prefix due to having a mismatch between the two different ways of mentioning users

## Feature
N/A
