### PR TITLE
DB Structure Improvements

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandManager.java
@@ -55,7 +55,7 @@ public class CommandManager {
 
     public ICommandMain getCommand(String command, GuildData data) {
         for (ICommandMain cmd : commands) {
-            if (data.getCommandAliases(cmd).contains(command)) {
+            if (data.getCoreSettings().getCommandAliases(cmd).contains(command)) {
                 return cmd;
             }
         }

--- a/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/commandmeta/CommandManager.java
@@ -8,7 +8,6 @@ package org.cascadebot.cascadebot.commandmeta;
 import lombok.Getter;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.cascadebot.cascadebot.ShutdownHandler;
-import org.cascadebot.cascadebot.data.language.Locale;
 import org.cascadebot.cascadebot.data.objects.GuildData;
 import org.cascadebot.cascadebot.utils.ReflectionUtils;
 import org.slf4j.Logger;
@@ -55,7 +54,7 @@ public class CommandManager {
 
     public ICommandMain getCommand(String command, GuildData data) {
         for (ICommandMain cmd : commands) {
-            if (data.getCoreSettings().getCommandAliases(cmd).contains(command)) {
+            if (data.getCore().getCommandAliases(cmd).contains(command)) {
                 return cmd;
             }
         }

--- a/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildInfoSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/developer/GuildInfoSubCommand.java
@@ -52,7 +52,7 @@ public class GuildInfoSubCommand implements ISubCommand {
 
         String modules = Arrays.stream(Module.values())
                              .map(module -> FormatUtils.formatEnum(module) + " - " +
-                                     (finalDataForList.getCoreSettings().isModuleEnabled(module) ? UnicodeConstants.TICK : UnicodeConstants.RED_CROSS))
+                                     (finalDataForList.getCore().isModuleEnabled(module) ? UnicodeConstants.TICK : UnicodeConstants.RED_CROSS))
                              .collect(Collectors.joining("\n"));
 
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleDisableSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/ModuleDisableSubCommand.java
@@ -26,7 +26,7 @@ public class ModuleDisableSubCommand implements ISubCommand {
 
         if (module != null) {
             try {
-                if (context.getData().getCoreSettings().disableModule(module)) {
+                if (context.getData().getCore().disableModule(module)) {
                     // If module wasn't already disabled
                     context.getTypedMessaging().replySuccess(context.i18n("commands.module.disable.disabled", module.toString()));
                 } else {

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
@@ -20,7 +20,7 @@ public class TagCategorySubCommand implements ISubCommand {
             return;
         }
 
-        Tag tag = context.getData().getManagement().getTags().get(context.getArg(0));
+        Tag tag = context.getData().getManagement().getTag(context.getArg(0));
 
         String tagName = context.getArg(0).toLowerCase();
         String category = context.getArg(1).toLowerCase();

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCategorySubCommand.java
@@ -20,7 +20,7 @@ public class TagCategorySubCommand implements ISubCommand {
             return;
         }
 
-        Tag tag = context.getCoreSettings().getTags().get(context.getArg(0));
+        Tag tag = context.getData().getManagement().getTags().get(context.getArg(0));
 
         String tagName = context.getArg(0).toLowerCase();
         String category = context.getArg(1).toLowerCase();

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
@@ -26,12 +26,12 @@ public class TagCommand implements ICommandMain {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (!context.getData().getManagement().getTags().containsKey(context.getArg(0))) {
+        if (!context.getData().getManagement().hasTag(context.getArg(0))) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;
         }
 
-        Tag tag = context.getData().getManagement().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTag(tagName);
         context.reply(tag.formatTag(context));
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCommand.java
@@ -26,12 +26,12 @@ public class TagCommand implements ICommandMain {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (!context.getCoreSettings().getTags().containsKey(context.getArg(0))) {
+        if (!context.getData().getManagement().getTags().containsKey(context.getArg(0))) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;
         }
 
-        Tag tag = context.getCoreSettings().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTags().get(tagName);
         context.reply(tag.formatTag(context));
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
@@ -24,7 +24,7 @@ public class TagCreateSubCommand implements ISubCommand {
         boolean warnUppercase = !context.getArg(0).equals(context.getArg(0).toLowerCase());
         String tagName = context.getArg(0).toLowerCase();
 
-        if (context.getCoreSettings().getTags().containsKey(tagName)) {
+        if (context.getData().getManagement().getTags().containsKey(tagName)) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.create.tag_already_exists", tagName));
             return;
         }
@@ -35,7 +35,7 @@ public class TagCreateSubCommand implements ISubCommand {
             message += "\n\n" + context.i18n("commands.tag.create.warn_uppercase");
         }
 
-        context.getCoreSettings().getTags().put(context.getArg(0), new Tag(context.getMessage(1), "tag"));
+        context.getData().getManagement().getTags().put(context.getArg(0), new Tag(context.getMessage(1), "tag"));
         context.getTypedMessaging().replySuccess(message);
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagCreateSubCommand.java
@@ -24,7 +24,7 @@ public class TagCreateSubCommand implements ISubCommand {
         boolean warnUppercase = !context.getArg(0).equals(context.getArg(0).toLowerCase());
         String tagName = context.getArg(0).toLowerCase();
 
-        if (context.getData().getManagement().getTags().containsKey(tagName)) {
+        if (context.getData().getManagement().hasTag(tagName)) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.create.tag_already_exists", tagName));
             return;
         }
@@ -36,7 +36,7 @@ public class TagCreateSubCommand implements ISubCommand {
         }
 
         Tag tag = new Tag(context.getMessage(1), "tag", context.getArg(0));
-        context.getData().getCoreSettings().addTag(context.getArg(0), tag);
+        context.getData().getManagement().addTag(context.getArg(0), tag);
         context.getData().getPermissionsManager().registerGuildPermission(tag.getInternalPermission());
         context.getTypedMessaging().replySuccess(message);
     }

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
@@ -21,7 +21,7 @@ public class TagDeleteSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (context.getData().getManagement().getTags().remove(tagName) != null) {
+        if (context.getData().getManagement().removeTag(tagName)) {
             context.getTypedMessaging().replySuccess(context.i18n("commands.tag.delete.successfully_deleted_tag"));
         } else {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.delete.tag_doesnt_exist", tagName));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagDeleteSubCommand.java
@@ -21,7 +21,7 @@ public class TagDeleteSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (context.getCoreSettings().getTags().remove(tagName) != null) {
+        if (context.getData().getManagement().getTags().remove(tagName) != null) {
             context.getTypedMessaging().replySuccess(context.i18n("commands.tag.delete.successfully_deleted_tag"));
         } else {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.delete.tag_doesnt_exist", tagName));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
@@ -22,7 +22,7 @@ public class TagEditSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        Tag tag = context.getCoreSettings().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTags().get(tagName);
         if (tag == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagEditSubCommand.java
@@ -22,7 +22,7 @@ public class TagEditSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        Tag tag = context.getData().getManagement().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTag(tagName);
         if (tag == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagListSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagListSubCommand.java
@@ -17,7 +17,7 @@ public class TagListSubCommand implements ISubCommand {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
-        Map<String, Tag> tags = context.getCoreSettings().getTags();
+        Map<String, Tag> tags = context.getData().getManagement().getTags();
 
         if (tags.size() == 0) {
             context.getTypedMessaging().replyWarning(context.i18n("commands.tag.list.no_tags_found"));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
@@ -24,12 +24,12 @@ public class TagRawSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (!context.getCoreSettings().getTags().containsKey(tagName)) {
+        if (!context.getData().getManagement().getTags().containsKey(tagName)) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;
         }
 
-        Tag tag = context.getCoreSettings().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTags().get(tagName);
         EmbedBuilder builder = MessagingObjects.getClearThreadLocalEmbedBuilder();
         builder.setTitle(context.i18n("words.tag") + ": " + tagName);
         builder.setDescription("```" + tag.getContent() + "```");

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/TagRawSubCommand.java
@@ -24,12 +24,12 @@ public class TagRawSubCommand implements ISubCommand {
 
         String tagName = context.getArg(0).toLowerCase();
 
-        if (!context.getData().getManagement().getTags().containsKey(tagName)) {
+        if (!context.getData().getManagement().hasTag(tagName)) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.tag.cannot_find_tag", tagName));
             return;
         }
 
-        Tag tag = context.getData().getManagement().getTags().get(tagName);
+        Tag tag = context.getData().getManagement().getTag(tagName);
         EmbedBuilder builder = MessagingObjects.getClearThreadLocalEmbedBuilder();
         builder.setTitle(context.i18n("words.tag") + ": " + tagName);
         builder.setDescription("```" + tag.getContent() + "```");

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionCreateSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionCreateSubCommand.java
@@ -21,7 +21,7 @@ public class GroupPermissionCreateSubCommand implements ISubCommand {
             return;
         }
 
-        Group group = context.getData().getPermissionSettings().createGroup(context.getArg(0));
+        Group group = context.getData().getManagement().getPermissions().createGroup(context.getArg(0));
         context.getTypedMessaging().replySuccess(context.i18n("commands.groupperms.create.success", context.getArg(0), group.getId()));
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionDeleteSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionDeleteSubCommand.java
@@ -17,7 +17,7 @@ public class GroupPermissionDeleteSubCommand implements ISubCommand {
         }
 
         PermissionCommandUtils.tryGetGroupFromString(context, context.getArg(0), group -> {
-            if (context.getData().getPermissionSettings().deleteGroup(group.getId())) {
+            if (context.getData().getManagement().getPermissions().deleteGroup(group.getId())) {
                 // If the group existed to delete and has been successfully deleted.
                 context.getTypedMessaging().replySuccess(context.i18n("commands.groupperms.delete.success", group.getName(), group.getId()));
             } else {

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionListSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionListSubCommand.java
@@ -25,15 +25,15 @@ public class GroupPermissionListSubCommand implements ISubCommand {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
-        if (context.getData().getPermissionSettings().getGroups().isEmpty()) {
+        if (context.getData().getManagement().getPermissions().getGroups().isEmpty()) {
             context.getTypedMessaging().replyWarning(context.i18n("commands.groupperms.list.no_groups"));
             return;
         }
 
         StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < context.getData().getPermissionSettings().getGroups().size(); i++) {
-            Group group = context.getData().getPermissionSettings().getGroups().get(i);
-            if (context.getData().getPermissionSettings().getMode().equals(PermissionMode.HIERARCHICAL)) {
+        for (int i = 0; i < context.getData().getManagement().getPermissions().getGroups().size(); i++) {
+            Group group = context.getData().getManagement().getPermissions().getGroups().get(i);
+            if (context.getData().getManagement().getPermissions().getMode().equals(PermissionMode.HIERARCHICAL)) {
                 stringBuilder.append(i).append(": ");
             }
             stringBuilder.append(group.getName()).append(" (").append(group.getId()).append(")\n");

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionMoveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionMoveSubCommand.java
@@ -25,7 +25,7 @@ public class GroupPermissionMoveSubCommand implements ISubCommand {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
-        if (context.getData().getPermissionSettings().getMode() == PermissionMode.MOST_RESTRICTIVE) {
+        if (context.getData().getManagement().getPermissions().getMode() == PermissionMode.MOST_RESTRICTIVE) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.groupperms.move.wrong_mode")); //TODO provide docs link
             return;
         }
@@ -37,31 +37,31 @@ public class GroupPermissionMoveSubCommand implements ISubCommand {
 
         PermissionCommandUtils.tryGetGroupFromString(context, context.getArg(0), group -> {
             if (context.getArgs().length > 1 && context.isArgInteger(1)) {
-                context.getData().getPermissionSettings().moveGroup(group, context.getArgAsInteger(1));
+                context.getData().getManagement().getPermissions().moveGroup(group, context.getArgAsInteger(1));
                 context.getTypedMessaging().replySuccess(context.i18n("commands.groupperms.move.moved", group.getName(), context.getArg(1)));
                 return;
             }
 
-            AtomicInteger currIndex = new AtomicInteger(context.getData().getPermissionSettings().getGroups().indexOf(group));
+            AtomicInteger currIndex = new AtomicInteger(context.getData().getManagement().getPermissions().getGroups().indexOf(group));
             ButtonGroup buttonGroup = new ButtonGroup(sender.getIdLong(), context.getChannel().getIdLong(), context.getGuild().getIdLong());
             buttonGroup.addButton(new Button.UnicodeButton(UnicodeConstants.ARROW_UP, (runner, channel, message) -> {
                 if (buttonGroup.getOwner().getIdLong() != runner.getIdLong()) {
                     return;
                 }
-                context.getData().getPermissionSettings().moveGroup(context.getData().getPermissionSettings().getGroups().get(currIndex.get()), currIndex.get() - 1);
+                context.getData().getManagement().getPermissions().moveGroup(context.getData().getManagement().getPermissions().getGroups().get(currIndex.get()), currIndex.get() - 1);
                 currIndex.addAndGet(-1);
-                message.editMessage(getGroupsList(group, context.getData().getPermissionSettings().getGroups())).queue();
+                message.editMessage(getGroupsList(group, context.getData().getManagement().getPermissions().getGroups())).queue();
             }));
             buttonGroup.addButton(new Button.UnicodeButton(UnicodeConstants.ARROW_DOWN, (runner, channel, message) -> {
                 if (buttonGroup.getOwner().getIdLong() != runner.getIdLong()) {
                     return;
                 }
-                context.getData().getPermissionSettings().moveGroup(context.getData().getPermissionSettings().getGroups().get(currIndex.get()), currIndex.get() + 1);
+                context.getData().getManagement().getPermissions().moveGroup(context.getData().getManagement().getPermissions().getGroups().get(currIndex.get()), currIndex.get() + 1);
                 currIndex.addAndGet(1);
-                message.editMessage(getGroupsList(group, context.getData().getPermissionSettings().getGroups())).queue();
+                message.editMessage(getGroupsList(group, context.getData().getManagement().getPermissions().getGroups())).queue();
             }));
 
-            context.getUiMessaging().sendButtonedMessage(getGroupsList(group, context.getData().getPermissionSettings().getGroups()), buttonGroup);
+            context.getUiMessaging().sendButtonedMessage(getGroupsList(group, context.getData().getManagement().getPermissions().getGroups()), buttonGroup);
         }, sender.getIdLong());
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionSwitchSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/GroupPermissionSwitchSubCommand.java
@@ -18,7 +18,7 @@ public class GroupPermissionSwitchSubCommand implements ISubCommand {
 
     @Override
     public void onCommand(Member sender, CommandContext context) {
-        PermissionMode mode = context.getData().getPermissionSettings().getMode();
+        PermissionMode mode = context.getData().getManagement().getPermissions().getMode();
         if (context.getArgs().length > 1) {
             mode = EnumUtils.getEnumIgnoreCase(PermissionMode.class, context.getArg(0));
             if (mode == null) {
@@ -36,7 +36,7 @@ public class GroupPermissionSwitchSubCommand implements ISubCommand {
             }
         }
 
-        context.getData().getPermissionSettings().setMode(mode);
+        context.getData().getManagement().getPermissions().setMode(mode);
         context.getTypedMessaging().replySuccess(context.i18n("commands.groupperms.switch.success", FormatUtils.formatEnum(mode, context.getLocale())));
     }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionAddSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionAddSubCommand.java
@@ -29,7 +29,7 @@ public class UserPermissionAddSubCommand implements ISubCommand {
             return;
         }
 
-        User user = context.getData().getPermissionSettings().getPermissionUser(member);
+        User user = context.getData().getManagement().getPermissions().getPermissionUser(member);
 
         if (!CascadeBot.INS.getPermissionsManager().isValidPermission(context.getGuild(), context.getArg(1))) {
             context.getTypedMessaging().replyDanger(context.i18n("responses.permission_not_exist", context.getArg(1)));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionGroupSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionGroupSubCommand.java
@@ -35,7 +35,7 @@ public class UserPermissionGroupSubCommand implements ISubCommand {
         }
 
         PermissionCommandUtils.tryGetGroupFromString(context, context.getArg(2), group -> {
-            User user = context.getData().getPermissionSettings().getPermissionUser(member);
+            User user = context.getData().getManagement().getPermissions().getPermissionUser(member);
             if (context.testForArg("put")) {
                 if (user.addGroup(group)) {
                     context.getTypedMessaging().replySuccess(context.i18n("commands.userperms.group.put.success", member.getUser().getAsTag(), group.getName()));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionListSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionListSubCommand.java
@@ -41,7 +41,7 @@ public class UserPermissionListSubCommand implements ISubCommand {
             return;
         }
 
-        User user = context.getData().getPermissionSettings().getPermissionUser(member);
+        User user = context.getData().getManagement().getPermissions().getPermissionUser(member);
 
         if (context.getArg(1).equalsIgnoreCase("groups")) {
             StringBuilder groupsBuilder = new StringBuilder();
@@ -51,7 +51,7 @@ public class UserPermissionListSubCommand implements ISubCommand {
             }
 
             for (String id : user.getGroupIds()) {
-                Group group = context.getData().getPermissionSettings().getGroupById(id);
+                Group group = context.getData().getManagement().getPermissions().getGroupById(id);
                 groupsBuilder.append(group.getName()).append(" (").append(group.getId()).append(")\n");
             }
             List<String> pageContent = PageUtils.splitString(groupsBuilder.toString(), 1000, '\n');

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionRemoveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionRemoveSubCommand.java
@@ -28,7 +28,7 @@ public class UserPermissionRemoveSubCommand implements ISubCommand {
             return;
         }
 
-        User user = context.getData().getPermissionSettings().getPermissionUser(member);
+        User user = context.getData().getManagement().getPermissions().getPermissionUser(member);
 
         if (user.removePermission(context.getArg(1))) {
             context.getTypedMessaging().replySuccess(context.i18n("commands.userperms.remove.success", context.getArg(1), member.getUser().getAsTag()));

--- a/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionTestSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/permission/UserPermissionTestSubCommand.java
@@ -34,7 +34,7 @@ public class UserPermissionTestSubCommand implements ISubCommand {
             return;
         }
 
-        if (context.getData().getPermissionSettings().hasPermission(target, context.getChannel(), perm, context.getCoreSettings())) {
+        if (context.getData().getManagement().getPermissions().hasPermission(target, context.getChannel(), perm, context.getCoreSettings())) {
             context.getTypedMessaging().replyInfo(context.i18n("commands.userperms.test.has", target.getUser().getAsTag(), perm.getPermission(context.getLocale())));
         } else {
             context.getTypedMessaging().replyInfo(context.i18n("commands.userperms.test.does_not_have", target.getUser().getAsTag(), perm.getPermission(context.getLocale())));

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/EqualizerCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/EqualizerCommand.java
@@ -82,8 +82,8 @@ public class EqualizerCommand implements ICommandMain {
             }
 
             player.setBand(currentBand.get(), ((float) gain) / 20f);
-            if (context.getData().getGuildMusic().getPreserveEqualizer()) {
-                context.getData().getGuildMusic().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
+            if (context.getData().getMusicSettings().getPreserveEqualizer()) {
+                context.getData().getMusicSettings().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
             }
 
             message.editMessage(getEqualizerEmbed(player.getCurrentBands(), currentBand.get(), runner.getUser(), context).build()).override(true).queue();
@@ -100,8 +100,8 @@ public class EqualizerCommand implements ICommandMain {
             }
 
             player.setBand(currentBand.get(), ((float) gain) / 20f);
-            if (context.getData().getGuildMusic().getPreserveEqualizer()) {
-                context.getData().getGuildMusic().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
+            if (context.getData().getMusicSettings().getPreserveEqualizer()) {
+                context.getData().getMusicSettings().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
             }
 
             message.editMessage(getEqualizerEmbed(player.getCurrentBands(), currentBand.get(), runner.getUser(), context).build()).override(true).queue();

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/EqualizerCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/EqualizerCommand.java
@@ -82,8 +82,8 @@ public class EqualizerCommand implements ICommandMain {
             }
 
             player.setBand(currentBand.get(), ((float) gain) / 20f);
-            if (context.getData().getMusicSettings().getPreserveEqualizer()) {
-                context.getData().getMusicSettings().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
+            if (context.getData().getMusic().getPreserveEqualizer()) {
+                context.getData().getMusic().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
             }
 
             message.editMessage(getEqualizerEmbed(player.getCurrentBands(), currentBand.get(), runner.getUser(), context).build()).override(true).queue();
@@ -100,8 +100,8 @@ public class EqualizerCommand implements ICommandMain {
             }
 
             player.setBand(currentBand.get(), ((float) gain) / 20f);
-            if (context.getData().getMusicSettings().getPreserveEqualizer()) {
-                context.getData().getMusicSettings().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
+            if (context.getData().getMusic().getPreserveEqualizer()) {
+                context.getData().getMusic().getEqualizerBands().replace(currentBand.get(), ((float) gain) / 20f);
             }
 
             message.editMessage(getEqualizerEmbed(player.getCurrentBands(), currentBand.get(), runner.getUser(), context).build()).override(true).queue();

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/PlayingCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/PlayingCommand.java
@@ -149,7 +149,7 @@ public class PlayingCommand implements ICommandMain {
         embedBuilder.addField(Language.i18n(guildId, "words.status"), player.isPaused() ? UnicodeConstants.PAUSE + " " + Language.i18n(guildId, "words.paused") : UnicodeConstants.PLAY + " " + Language.i18n(guildId, "words.playing"), true);
 
         if (!track.getInfo().isStream) {
-            embedBuilder.addField(Language.i18n(guildId, "words.progress"), player.getTrackProgressBar(GuildDataManager.getGuildData(guildId).getCoreSettings().getUseEmbedForMessages()), false);
+            embedBuilder.addField(Language.i18n(guildId, "words.progress"), player.getTrackProgressBar(GuildDataManager.getGuildData(guildId).getCore().getUseEmbedForMessages()), false);
         }
 
         embedBuilder.addField("Amount played", FormatUtils.formatLongTimeMills(player.getTrackPosition()) + " / " +

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
@@ -48,8 +48,8 @@ public class VolumeCommand implements ICommandMain {
                             @Override
                             public void execute() {
                                 player.setVolume(volume);
-                                if (context.getData().getMusicSettings().getPreserveVolume()) {
-                                    context.getData().getMusicSettings().setVolume(volume);
+                                if (context.getData().getMusic().getPreserveVolume()) {
+                                    context.getData().getMusic().setVolume(volume);
                                 }
                                 context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_set", player.getVolume()));
                             }
@@ -68,8 +68,8 @@ public class VolumeCommand implements ICommandMain {
             context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_already_set", player.getVolume()));
         } else {
             player.setVolume(volume);
-            if (context.getData().getMusicSettings().getPreserveVolume()) {
-                context.getData().getMusicSettings().setVolume(volume);
+            if (context.getData().getMusic().getPreserveVolume()) {
+                context.getData().getMusic().setVolume(volume);
             }
             context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_set", player.getVolume()));
         }

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/VolumeCommand.java
@@ -48,8 +48,8 @@ public class VolumeCommand implements ICommandMain {
                             @Override
                             public void execute() {
                                 player.setVolume(volume);
-                                if (context.getData().getGuildMusic().getPreserveVolume()) {
-                                    context.getData().getGuildMusic().setVolume(volume);
+                                if (context.getData().getMusicSettings().getPreserveVolume()) {
+                                    context.getData().getMusicSettings().setVolume(volume);
                                 }
                                 context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_set", player.getVolume()));
                             }
@@ -68,8 +68,8 @@ public class VolumeCommand implements ICommandMain {
             context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_already_set", player.getVolume()));
         } else {
             player.setVolume(volume);
-            if (context.getData().getGuildMusic().getPreserveVolume()) {
-                context.getData().getGuildMusic().setVolume(volume);
+            if (context.getData().getMusicSettings().getPreserveVolume()) {
+                context.getData().getMusicSettings().setVolume(volume);
             }
             context.getTypedMessaging().replyInfo(context.i18n("commands.volume.volume_set", player.getVolume()));
         }

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoAddSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoAddSubCommand.java
@@ -18,7 +18,7 @@ public class TodoAddSubCommand implements ISubCommand {
         }
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));
@@ -31,7 +31,7 @@ public class TodoAddSubCommand implements ISubCommand {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit", owner.getAsMention()));
             } else {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit_no_owner"));
-                context.getData().getUsefulSettings().deleteTodoList(todoName);
+                context.getData().getUseful().deleteTodoList(todoName);
             }
             return;
         }

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoAddUserSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoAddUserSubCommand.java
@@ -17,7 +17,7 @@ public class TodoAddUserSubCommand implements ISubCommand {
         }
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoCreateSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoCreateSubCommand.java
@@ -18,7 +18,7 @@ public class TodoCreateSubCommand implements ISubCommand {
         // Warn if the original argument contains uppercase letters
         boolean warnUppercase = !context.getArg(0).equals(context.getArg(0).toLowerCase());
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().createTodoList(todoName, context.getMember().getIdLong());
+        TodoList todoList = context.getData().getUseful().createTodoList(todoName, context.getMember().getIdLong());
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.create.list_exists"));

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoRemoveSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoRemoveSubCommand.java
@@ -23,7 +23,7 @@ public class TodoRemoveSubCommand implements ISubCommand {
         }
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));
@@ -36,7 +36,7 @@ public class TodoRemoveSubCommand implements ISubCommand {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit", owner.getAsMention()));
             } else {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit_no_owner"));
-                context.getData().getUsefulSettings().deleteTodoList(todoName);
+                context.getData().getUseful().deleteTodoList(todoName);
             }
             return;
         }
@@ -56,7 +56,7 @@ public class TodoRemoveSubCommand implements ISubCommand {
         context.getTypedMessaging().replySuccess(builder);
 
         if (todoList.getItems().size() == 0) {
-            context.getData().getUsefulSettings().deleteTodoList(todoName);
+            context.getData().getUseful().deleteTodoList(todoName);
             context.reply(context.i18n("commands.todo.remove.deleted"));
         }
 

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoRemoveUserSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoRemoveUserSubCommand.java
@@ -17,7 +17,7 @@ public class TodoRemoveUserSubCommand implements ISubCommand {
         }
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoSendSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoSendSubCommand.java
@@ -29,7 +29,7 @@ public class TodoSendSubCommand implements ISubCommand {
         //TODO make sure channel is in guild and that this user can see said channel. probably should do this in the utils
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));
@@ -42,7 +42,7 @@ public class TodoSendSubCommand implements ISubCommand {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit", owner.getAsMention()));
             } else {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit_no_owner"));
-                context.getData().getUsefulSettings().deleteTodoList(todoName);
+                context.getData().getUseful().deleteTodoList(todoName);
             }
             return;
         }

--- a/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoViewSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/useful/TodoViewSubCommand.java
@@ -22,7 +22,7 @@ public class TodoViewSubCommand implements ISubCommand {
         }
 
         String todoName = context.getArg(0).toLowerCase();
-        TodoList todoList = context.getData().getUsefulSettings().getTodoList(todoName);
+        TodoList todoList = context.getData().getUseful().getTodoList(todoName);
 
         if (todoList == null) {
             context.getTypedMessaging().replyDanger(context.i18n("commands.todo.list_does_not_exist", todoName));
@@ -35,7 +35,7 @@ public class TodoViewSubCommand implements ISubCommand {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit", owner.getAsMention()));
             } else {
                 context.getTypedMessaging().replyDanger(context.i18n("commands.todo.cannot_edit_no_owner"));
-                context.getData().getUsefulSettings().deleteTodoList(todoName);
+                context.getData().getUseful().deleteTodoList(todoName);
             }
             return;
         }

--- a/src/main/java/org/cascadebot/cascadebot/data/objects/PerGuildPermissionsManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/data/objects/PerGuildPermissionsManager.java
@@ -32,7 +32,7 @@ public class PerGuildPermissionsManager {
 
     // Method that registers all hte permissions after the data was loaded
     public void registerPermissions(GuildData data) {
-        for (Map.Entry<String, Tag> entry : data.getCoreSettings().getTags().entrySet()) {
+        for (Map.Entry<String, Tag> entry : data.getManagement().getTags().entrySet()) {
             registerGuildPermission(entry.getValue().getInternalPermission());
         }
     }

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -134,10 +134,10 @@ public class CommandListener extends ListenerAdapter {
             }
             dispatchCommand(cmd, context);
         } else {
-            if (guildData.getCore().getAllowTagCommands()) {
+            if (guildData.getManagement().getAllowTagCommands()) {
                 String tagName = trigger.toLowerCase();
-                if (guildData.getCore().getTags().containsKey(tagName)) {
-                    Tag tag = guildData.getCore().getTags().get(tagName);
+                if (guildData.getManagement().getTags().containsKey(tagName)) {
+                    Tag tag = guildData.getManagement().getTags().get(tagName);
 
                     context.reply(tag.formatTag(context)); //TODO perms for tags
                     CascadeBot.LOGGER.info("Tag {} executed by {} with args {}", tagName, context.getUser().getAsTag(), Arrays.toString(context.getArgs()));

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -136,8 +136,8 @@ public class CommandListener extends ListenerAdapter {
         } else {
             if (guildData.getManagement().getAllowTagCommands()) {
                 String tagName = trigger.toLowerCase();
-                if (guildData.getManagement().getTags().containsKey(tagName)) {
-                    Tag tag = guildData.getManagement().getTags().get(tagName);
+                if (guildData.getManagement().hasTag(tagName)) {
+                    Tag tag = guildData.getManagement().getTag(tagName);
 
                     context.reply(tag.formatTag(context)); //TODO perms for tags
                     CascadeBot.LOGGER.info("Tag {} executed by {} with args {}", tagName, context.getUser().getAsTag(), Arrays.toString(context.getArgs()));

--- a/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/CommandListener.java
@@ -73,7 +73,7 @@ public class CommandListener extends ListenerAdapter {
             return;
         }
 
-        String prefix = guildData.getCoreSettings().getPrefix();
+        String prefix = guildData.getCore().getPrefix();
         boolean isMention = false;
 
         String commandWithArgs = null;
@@ -82,10 +82,10 @@ public class CommandListener extends ListenerAdapter {
 
         if (message.startsWith(prefix)) {
             commandWithArgs = message.substring(prefix.length()); // Remove prefix from command
-        } else if (guildData.getCoreSettings().getMentionPrefix() && message.matches("^<@!?" + event.getJDA().getSelfUser().getId() + ">.*")) {
+        } else if (guildData.getCore().getMentionPrefix() && message.matches("^<@!?" + event.getJDA().getSelfUser().getId() + ">.*")) {
             commandWithArgs = message.substring(message.indexOf('>') + 1).trim();
             isMention = true;
-        } else if (message.startsWith(Config.INS.getDefaultPrefix() + Language.i18n(guildData.getLocale(), "commands.prefix.command")) && !Config.INS.getDefaultPrefix().equals(guildData.getCoreSettings().getPrefix())) {
+        } else if (message.startsWith(Config.INS.getDefaultPrefix() + Language.i18n(guildData.getLocale(), "commands.prefix.command")) && !Config.INS.getDefaultPrefix().equals(guildData.getCore().getPrefix())) {
             commandWithArgs = message.substring(Config.INS.getDefaultPrefix().length());
         } else {
             return;
@@ -115,10 +115,10 @@ public class CommandListener extends ListenerAdapter {
         CommandContext context = new CommandContext(cmd, event.getJDA(), event.getChannel(), event.getMessage(), event.getGuild(), guildData, args, event.getMember(), trigger, isMention);
         if (cmd != null) {
             Metrics.INS.commandsSubmitted.labels(cmd.getClass().getSimpleName()).inc();
-            if (!cmd.getModule().isPrivate() && !guildData.getCoreSettings().isModuleEnabled(cmd.getModule())) {
-                if (guildData.getCoreSettings().getShowModuleErrors() || Environment.isDevelopment()) {
+            if (!cmd.getModule().isPrivate() && !guildData.getCore().isModuleEnabled(cmd.getModule())) {
+                if (guildData.getCore().getShowModuleErrors() || Environment.isDevelopment()) {
                     EmbedBuilder builder = MessagingObjects.getStandardMessageEmbed(context.i18n("responses.module_for_command_disabled", FormatUtils.formatEnum(cmd.getModule(), context.getLocale()), trigger), event.getAuthor());
-                    Messaging.sendEmbedMessage(MessageType.DANGER, event.getChannel(), builder, guildData.getCoreSettings().getUseEmbedForMessages());
+                    Messaging.sendEmbedMessage(MessageType.DANGER, event.getChannel(), builder, guildData.getCore().getUseEmbedForMessages());
                 }
                 // TODO: Modlog?
                 return;
@@ -134,10 +134,10 @@ public class CommandListener extends ListenerAdapter {
             }
             dispatchCommand(cmd, context);
         } else {
-            if (guildData.getCoreSettings().getAllowTagCommands()) {
+            if (guildData.getCore().getAllowTagCommands()) {
                 String tagName = trigger.toLowerCase();
-                if (guildData.getCoreSettings().getTags().containsKey(tagName)) {
-                    Tag tag = guildData.getCoreSettings().getTags().get(tagName);
+                if (guildData.getCore().getTags().containsKey(tagName)) {
+                    Tag tag = guildData.getCore().getTags().get(tagName);
 
                     context.reply(tag.formatTag(context)); //TODO perms for tags
                     CascadeBot.LOGGER.info("Tag {} executed by {} with args {}", tagName, context.getUser().getAsTag(), Arrays.toString(context.getArgs()));

--- a/src/main/java/org/cascadebot/cascadebot/events/GeneralEventListener.java
+++ b/src/main/java/org/cascadebot/cascadebot/events/GeneralEventListener.java
@@ -77,7 +77,7 @@ public class GeneralEventListener extends ListenerAdapter {
 
     @Override
     public void onRoleDelete(RoleDeleteEvent event) {
-        for (Group group : GuildDataManager.getGuildData(event.getGuild().getIdLong()).getPermissionSettings().getGroups()) {
+        for (Group group : GuildDataManager.getGuildData(event.getGuild().getIdLong()).getManagement().getPermissions().getGroups()) {
             group.unlinkRole(event.getRole().getIdLong());
         }
     }

--- a/src/main/java/org/cascadebot/cascadebot/permissions/PermissionsManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/permissions/PermissionsManager.java
@@ -155,7 +155,7 @@ public class PermissionsManager {
             return userLevel.isAuthorised(levelToCheck);
         } else {
             if (command.getPermission() == null) return true;
-            return guildData.getPermissionSettings().hasPermission(member, command.getPermission(), guildData.getCoreSettings());
+            return guildData.getPermissionSettings().hasPermission(member, command.getPermission(), guildData.getCore());
         }
         // return false;
     }

--- a/src/main/java/org/cascadebot/cascadebot/permissions/PermissionsManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/permissions/PermissionsManager.java
@@ -155,7 +155,7 @@ public class PermissionsManager {
             return userLevel.isAuthorised(levelToCheck);
         } else {
             if (command.getPermission() == null) return true;
-            return guildData.getPermissionSettings().hasPermission(member, command.getPermission(), guildData.getCore());
+            return guildData.getManagement().getPermissions().hasPermission(member, command.getPermission(), guildData.getCore());
         }
         // return false;
     }

--- a/src/main/java/org/cascadebot/cascadebot/utils/ConfirmUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/ConfirmUtils.java
@@ -36,7 +36,7 @@ public class ConfirmUtils {
     //region Confirm Action
     public static boolean confirmAction(long userId, String actionKey, TextChannel channel, MessageType type, String message, long buttonDelay, long expiry, boolean isCancellable, ConfirmRunnable action) {
         GuildData guildData = GuildDataManager.getGuildData(channel.getGuild().getIdLong());
-        boolean useEmbed = guildData.getCoreSettings().getUseEmbedForMessages();
+        boolean useEmbed = guildData.getCore().getUseEmbedForMessages();
         Message sentMessage;
         try {
             sentMessage = Messaging.sendMessage(type, channel, message, useEmbed).get();

--- a/src/main/java/org/cascadebot/cascadebot/utils/PermissionCommandUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/PermissionCommandUtils.java
@@ -25,13 +25,13 @@ import java.util.function.Consumer;
 public class PermissionCommandUtils {
 
     public static void tryGetGroupFromString(CommandContext context, String s, Consumer<Group> groupConsumer, long sender) {
-        Group groupById = context.getData().getPermissionSettings().getGroupById(s);
+        Group groupById = context.getData().getManagement().getPermissions().getGroupById(s);
         if (groupById != null) {
             groupConsumer.accept(groupById);
             return;
         }
 
-        List<Group> groupList = context.getData().getPermissionSettings().getGroupsByName(s);
+        List<Group> groupList = context.getData().getManagement().getPermissions().getGroupsByName(s);
         if (groupList.size() == 1) {
             groupConsumer.accept(groupList.get(0));
             return;

--- a/src/main/java/org/cascadebot/cascadebot/utils/PurgeUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/PurgeUtils.java
@@ -44,7 +44,7 @@ public class PurgeUtils {
                 break;
             }
             
-            if (!context.getData().getModerationSettings().isPurgePinnedMessages() && message.isPinned()) {
+            if (!context.getData().getModeration().isPurgePinnedMessages() && message.isPinned()) {
                     continue;
             }
 

--- a/src/main/java/org/cascadebot/cascadebot/utils/PurgeUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/PurgeUtils.java
@@ -7,7 +7,6 @@
 package org.cascadebot.cascadebot.utils;
 
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.User;
 import org.cascadebot.cascadebot.commandmeta.CommandContext;
 import org.cascadebot.cascadebot.data.objects.PurgeCriteria;
 
@@ -45,7 +44,7 @@ public class PurgeUtils {
                 break;
             }
             
-            if (!context.getData().getGuildModeration().isPurgePinnedMessages() && message.isPinned()) {
+            if (!context.getData().getModerationSettings().isPurgePinnedMessages() && message.isPinned()) {
                     continue;
             }
 

--- a/src/main/java/org/cascadebot/cascadebot/utils/pagination/PageObjects.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/pagination/PageObjects.java
@@ -38,7 +38,7 @@ public class PageObjects {
         @Override
         public void pageShow(Message message, int page, int total) {
             GuildData data = GuildDataManager.getGuildData(message.getTextChannel().getGuild().getIdLong());
-            if (data.getCoreSettings().getUseEmbedForMessages()) {
+            if (data.getCore().getUseEmbedForMessages()) {
                 if (numbersInEmbed) {
                     embed.setFooter(Language.i18n(data.getLocale(), "page_objects.page_footer", page, total), message.getAuthor().getAvatarUrl());
                     message.editMessage(embed.build()).override(true).queue();

--- a/src/main/kotlin/org/cascadebot/cascadebot/commandmeta/CommandContext.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/commandmeta/CommandContext.kt
@@ -75,7 +75,7 @@ class CommandContext(
     fun getArgAsLong(index: Int): Long? = args[index].toLongOrNull()
 
     @Deprecated("This is only here for Java interop. Should not be used in Kotlin!", ReplaceWith("data.coreSettings"))
-    fun getCoreSettings() : GuildSettingsCore = data.coreSettings
+    fun getCoreSettings() : GuildSettingsCore = data.core
 
     /**
      * Tests for an argument of a particular id. This check it exists at the position and,
@@ -134,10 +134,10 @@ class CommandContext(
             if (command is ISubCommand) {
                 parent = command.parent()
             }
-            val commandString: String = data.coreSettings.prefix + if (parent == null) "" else "$parent "
+            val commandString: String = data.core.prefix + if (parent == null) "" else "$parent "
             parentArg.getUsageString(locale, commandString)
         } else {
-            "`" + data.coreSettings.prefix + command.command(locale) + "` - " + command.description(locale)
+            "`" + data.core.prefix + command.command(locale) + "` - " + command.description(locale)
         }
     }
 
@@ -179,15 +179,15 @@ class CommandContext(
             CascadeBot.LOGGER.warn("Could not check permission {} as it does not exist!!", permission)
             return false
         }
-        return data.managementSettings.permissions.hasPermission(member, channel, cascadePermission, data.coreSettings)
+        return data.management.permissions.hasPermission(member, channel, cascadePermission, data.core)
     }
 
     fun hasPermission(permission: CascadePermission?): Boolean {
-        return permission != null && data.managementSettings.permissions.hasPermission(member, channel, permission, data.coreSettings)
+        return permission != null && data.management.permissions.hasPermission(member, channel, permission, data.core)
     }
 
     fun hasPermission(member: Member?, channel: GuildChannel?, permission: CascadePermission?): Boolean {
-        return permission != null && data.managementSettings.permissions.hasPermission(member, channel, permission, data.coreSettings)
+        return permission != null && data.management.permissions.hasPermission(member, channel, permission, data.core)
     }
 
     fun runOtherCommand(command: String?, sender: Member?, context: CommandContext) {

--- a/src/main/kotlin/org/cascadebot/cascadebot/commandmeta/CommandContext.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/commandmeta/CommandContext.kt
@@ -179,15 +179,15 @@ class CommandContext(
             CascadeBot.LOGGER.warn("Could not check permission {} as it does not exist!!", permission)
             return false
         }
-        return data.permissionSettings.hasPermission(member, channel, cascadePermission, data.coreSettings)
+        return data.managementSettings.permissions.hasPermission(member, channel, cascadePermission, data.coreSettings)
     }
 
     fun hasPermission(permission: CascadePermission?): Boolean {
-        return permission != null && data.permissionSettings.hasPermission(member, channel, permission, data.coreSettings)
+        return permission != null && data.managementSettings.permissions.hasPermission(member, channel, permission, data.coreSettings)
     }
 
     fun hasPermission(member: Member?, channel: GuildChannel?, permission: CascadePermission?): Boolean {
-        return permission != null && data.permissionSettings.hasPermission(member, channel, permission, data.coreSettings)
+        return permission != null && data.managementSettings.permissions.hasPermission(member, channel, permission, data.coreSettings)
     }
 
     fun runOtherCommand(command: String?, sender: Member?, context: CommandContext) {

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/language/Language.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/language/Language.kt
@@ -62,7 +62,7 @@ object Language {
             if (languages[locale]!!.getString(path).isPresent) {
                 val format = MessageFormat(languages[locale]!!.getString(path).get(), locale.uLocale)
                 var message = format.format(args)
-                message = FormatUtils.formatPrefix(GuildDataManager.getGuildData(guildId).coreSettings.prefix, message)
+                message = FormatUtils.formatPrefix(GuildDataManager.getGuildData(guildId).core.prefix, message)
                 FormatUtils.formatUnicode(message)
             } else {
                 CascadeBot.LOGGER.warn("Cannot find a language string matching the path '{}'", path)

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
@@ -5,7 +5,6 @@ import de.bild.codec.annotations.Id
 import de.bild.codec.annotations.Transient
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageChannel
-import org.bson.codecs.pojo.annotations.BsonIgnore
 import org.cascadebot.cascadebot.CascadeBot
 import org.cascadebot.cascadebot.commandmeta.ICommandMain
 import org.cascadebot.cascadebot.commandmeta.Module
@@ -38,11 +37,11 @@ class GuildData(@field:Id val guildId: Long) {
     val locale: Locale = Locale.getDefaultLocale()
 
     //region Guild data containers
-    val coreSettings = GuildSettingsCore(guildId)
+    val coreSettings = GuildSettingsCore()
     val usefulSettings = GuildSettingsUseful()
-    val guildModeration = GuildSettingsModeration()
-    val guildMusic = GuildSettingsMusic()
+    val moderationSettings = GuildSettingsModeration()
     val permissionSettings = GuildPermissions()
+    val musicSettings = GuildSettingsMusic()
     //endregion
 
     //region Transient fields
@@ -63,13 +62,13 @@ class GuildData(@field:Id val guildId: Long) {
 
     private fun loadMusicSettings() {
         val player = CascadeBot.INS.musicHandler.getPlayer(guildId)!!
-        if (guildMusic.preserveVolume) {
-            player.volume = guildMusic.volume
+        if (musicSettings.preserveVolume) {
+            player.volume = musicSettings.volume
         }
-        if (guildMusic.preserveEqualizer) {
+        if (musicSettings.preserveEqualizer) {
             if (CascadeBot.INS.musicHandler.lavalinkEnabled) {
                 if (player is CascadeLavalinkPlayer) {
-                    player.setBands(guildMusic.equalizerBands)
+                    player.setBands(musicSettings.equalizerBands)
                 }
             }
         }

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
@@ -6,17 +6,13 @@ import de.bild.codec.annotations.Transient
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageChannel
 import org.cascadebot.cascadebot.CascadeBot
-import org.cascadebot.cascadebot.commandmeta.ICommandMain
-import org.cascadebot.cascadebot.commandmeta.Module
 import org.cascadebot.cascadebot.data.language.Locale
 import org.cascadebot.cascadebot.music.CascadeLavalinkPlayer
 import org.cascadebot.cascadebot.utils.buttons.ButtonGroup
 import org.cascadebot.cascadebot.utils.buttons.ButtonsCache
 import org.cascadebot.cascadebot.utils.buttons.PersistentButtonGroup
 import org.cascadebot.cascadebot.utils.pagination.PageCache
-import java.util.Collections
 import java.util.Date
-import java.util.concurrent.ConcurrentHashMap
 
 class GuildData(@field:Id val guildId: Long) {
 
@@ -32,14 +28,14 @@ class GuildData(@field:Id val guildId: Long) {
 
     // TODO: Keep this here or remove it? It just serves as an accessor for the actual locale
     val locale: Locale
-        get() = coreSettings.locale
+        get() = core.locale
 
     //region Guild data containers
-    val coreSettings = GuildSettingsCore()
-    val usefulSettings = GuildSettingsUseful()
-    val moderationSettings = GuildSettingsModeration()
-    val managementSettings = GuildSettingsManagement()
-    val musicSettings = GuildSettingsMusic()
+    val core = GuildSettingsCore()
+    val useful = GuildSettingsUseful()
+    val moderation = GuildSettingsModeration()
+    val management = GuildSettingsManagement()
+    val music = GuildSettingsMusic()
     //endregion
 
     //region Transient fields
@@ -60,13 +56,13 @@ class GuildData(@field:Id val guildId: Long) {
 
     private fun loadMusicSettings() {
         val player = CascadeBot.INS.musicHandler.getPlayer(guildId)!!
-        if (musicSettings.preserveVolume) {
-            player.volume = musicSettings.volume
+        if (music.preserveVolume) {
+            player.volume = music.volume
         }
-        if (musicSettings.preserveEqualizer) {
+        if (music.preserveEqualizer) {
             if (CascadeBot.INS.musicHandler.lavalinkEnabled) {
                 if (player is CascadeLavalinkPlayer) {
-                    player.setBands(musicSettings.equalizerBands)
+                    player.setBands(music.equalizerBands)
                 }
             }
         }

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
@@ -30,9 +30,6 @@ class GuildSettingsCore {
     var adminsHaveAllPerms = true
 
     @Setting
-    var allowTagCommands = true
-
-    @Setting
     var helpHideCommandsNoPermission = true
 
     @Setting
@@ -48,10 +45,6 @@ class GuildSettingsCore {
 
     @Setting(directlyEditable = false)
     private val enabledModules: MutableSet<Module> = Sets.newConcurrentHashSet(Module.getModules(ModuleFlag.DEFAULT))
-
-    @Setting(directlyEditable = false)
-    val tags: ConcurrentHashMap<String, Tag> = ConcurrentHashMap()
-
 
     //region Modules
     fun enableModule(module: Module): Boolean {

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
@@ -6,11 +6,7 @@ import org.cascadebot.cascadebot.data.Config
 import java.util.concurrent.ConcurrentHashMap
 
 @SettingsContainer(module = Module.CORE)
-class GuildSettingsCore(guildId: Long) {
-
-    private constructor() : this(0L) {
-        // Private constructor for MongoDB
-    }
+class GuildSettingsCore {
 
     @Setting
     var mentionPrefix = false

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsCore.kt
@@ -5,7 +5,6 @@ import org.cascadebot.cascadebot.CascadeBot
 import org.cascadebot.cascadebot.commandmeta.ICommandMain
 import org.cascadebot.cascadebot.commandmeta.Module
 import org.cascadebot.cascadebot.data.Config
-import java.util.Collections
 import org.cascadebot.cascadebot.data.language.Locale
 import java.util.concurrent.ConcurrentHashMap
 
@@ -78,9 +77,6 @@ class GuildSettingsCore {
             getGuildCommandInfo(command).enabled = true
         }
     }
-    fun getTag(key: String): Tag? {
-        return tags[key]
-    }
 
     fun enableCommandByModule(module: Module) {
         if (module.isPrivate) return
@@ -136,18 +132,5 @@ class GuildSettingsCore {
     }
 
     //endregion
-
-
-    fun hasTag(key: String): Boolean {
-        return tags.containsKey(key)
-    }
-
-    fun addTag(key: String, tag: Tag) {
-        tags[key] = tag
-    }
-
-    fun removeTag(key: String): Boolean {
-        return tags.remove(key) != null
-    }
 
 }

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsManagement.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsManagement.kt
@@ -1,0 +1,18 @@
+package org.cascadebot.cascadebot.data.objects
+
+import org.cascadebot.cascadebot.commandmeta.Module
+import java.util.concurrent.ConcurrentHashMap
+
+@SettingsContainer(module = Module.MANAGEMENT)
+class GuildSettingsManagement {
+
+    @Setting
+    var allowTagCommands = true
+
+    @Setting(directlyEditable = false)
+    val tags: ConcurrentHashMap<String, Tag> = ConcurrentHashMap()
+
+    @Setting(directlyEditable = false)
+    val permissions = GuildPermissions()
+
+}

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsManagement.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildSettingsManagement.kt
@@ -15,4 +15,20 @@ class GuildSettingsManagement {
     @Setting(directlyEditable = false)
     val permissions = GuildPermissions()
 
+    fun getTag(key: String): Tag? {
+        return tags[key]
+    }
+
+    fun hasTag(key: String): Boolean {
+        return tags.containsKey(key)
+    }
+
+    fun addTag(key: String, tag: Tag) {
+        tags[key] = tag
+    }
+
+    fun removeTag(key: String): Boolean {
+        return tags.remove(key) != null
+    }
+
 }

--- a/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
@@ -273,7 +273,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
     })),
     SKIP_BUTTON_FORCE(Button.UnicodeButton(UnicodeConstants.FAST_FORWARD,  IButtonRunnable { runner: Member?, channel: TextChannel, message: Message ->
         val data = GuildDataManager.getGuildData(channel.guild.idLong)
-        if (!data.permissionSettings.hasPermission(runner, channel, CascadeBot.INS.permissionsManager.getPermission("skip.force"), data.core)) {
+        if (!data.management.permissions.hasPermission(runner, channel, CascadeBot.INS.permissionsManager.getPermission("skip.force"), data.core)) {
             return@IButtonRunnable
         }
         message.delete().queue(null, DiscordUtils.handleExpectedErrors(ErrorResponse.UNKNOWN_MESSAGE))

--- a/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
@@ -14,7 +14,7 @@ import org.cascadebot.cascadebot.utils.votes.VoteButtonGroup
 
 enum class PersistentButton(@field:Transient val button: Button) {
     TODO_BUTTON_CHECK(Button.UnicodeButton(UnicodeConstants.TICK,  IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -24,7 +24,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
         message.editMessage(todoList.todoListMessage).queue()
     })),
     TODO_BUTTON_UNCHECK(Button.UnicodeButton(UnicodeConstants.WHITE_HALLOW_SQUARE,  IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -34,7 +34,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
         message.editMessage(todoList.todoListMessage).queue()
     })),
     TODO_BUTTON_NAVIGATE_LEFT(Button.UnicodeButton(UnicodeConstants.BACKWARD_ARROW, IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -49,7 +49,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
         todoList.doCheckToggle(message)
     })),
     TODO_BUTTON_NAVIGATE_RIGHT(Button.UnicodeButton(UnicodeConstants.FORWARD_ARROW,  IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -64,7 +64,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
         todoList.doCheckToggle(message)
     })),
     TODO_BUTTON_NAVIGATE_UP(Button.UnicodeButton(UnicodeConstants.ARROW_UP,  IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -77,7 +77,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
         todoList.doCheckToggle(message)
     })),
     TODO_BUTTON_NAVIGATE_DOWN(Button.UnicodeButton(UnicodeConstants.ARROW_DOWN,  IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).usefulSettings.getTodoListByMessage(message.idLong)
+        val todoList = GuildDataManager.getGuildData(channel.guild.idLong).useful.getTodoListByMessage(message.idLong)
         if (!todoList.canUserEdit(runner.idLong)) {
             return@IButtonRunnable
         }
@@ -273,7 +273,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
     })),
     SKIP_BUTTON_FORCE(Button.UnicodeButton(UnicodeConstants.FAST_FORWARD,  IButtonRunnable { runner: Member?, channel: TextChannel, message: Message ->
         val data = GuildDataManager.getGuildData(channel.guild.idLong)
-        if (!data.permissionSettings.hasPermission(runner, channel, CascadeBot.INS.permissionsManager.getPermission("skip.force"), data.coreSettings)) {
+        if (!data.permissionSettings.hasPermission(runner, channel, CascadeBot.INS.permissionsManager.getPermission("skip.force"), data.core)) {
             return@IButtonRunnable
         }
         message.delete().queue(null, DiscordUtils.handleExpectedErrors(ErrorResponse.UNKNOWN_MESSAGE))


### PR DESCRIPTION
# Pull request

 - [x] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [x] I have tested all of my changes.
 
## Added/Changed
 - Guild ID has been removed from core settings as a parameter. It wasn't needed anyway
 - Move the `coreSettings.allowTagsCommand` setting into `management.allowTagsCommand`
 - Permissions have been moved into the management settings
 - Users are now stored as a `Map<String, User>` so a normal map can be used
 - Tags have been moved into management settings
 - Settings have all be renamed to just their module name to be consistent and concise.
 - Locale and command info has been moved into cores settings

## To Discuss
 - Storing the permission Groups in a `Map<String, Group>` comes with complexity because of hierarchy.

I would like to have this merged **after** per guild permissions #209 and #215 
