### PR TITLE
Add a check to respect role hierarchy when kicking or banning users

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/data/objects/GuildSettingsModeration.java
+++ b/src/main/java/org/cascadebot/cascadebot/data/objects/GuildSettingsModeration.java
@@ -20,4 +20,7 @@ public class GuildSettingsModeration {
     @Setting
     private boolean purgePinnedMessages = false;
 
+    @Setting
+    private boolean respectBanOrKickHierarchy = true;
+
 }

--- a/src/main/java/org/cascadebot/cascadebot/moderation/ModerationManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/moderation/ModerationManager.java
@@ -77,7 +77,7 @@ public class ModerationManager {
         } else if (target.equals(context.getSelfUser())) {
             context.getTypedMessaging().replyWarning(context.i18n("moderation_manager.cannot_action_bot", action.getName(context.getLocale())));
             return false;
-        } else if(!submitter.canInteract(context.getGuild().getMember(target)) && context.getData().getModeration().isRespectBanOrKickHierarchy()) {
+        } else if (context.getData().getModeration().isRespectBanOrKickHierarchy() && !submitter.canInteract(context.getGuild().getMember(target))) {
             context.getTypedMessaging().replyWarning(context.i18n("moderation_manager.user_cannot_action_superior", action.getName(context.getLocale()), target.getName()));
             return false;
         }

--- a/src/main/java/org/cascadebot/cascadebot/moderation/ModerationManager.java
+++ b/src/main/java/org/cascadebot/cascadebot/moderation/ModerationManager.java
@@ -77,6 +77,9 @@ public class ModerationManager {
         } else if (target.equals(context.getSelfUser())) {
             context.getTypedMessaging().replyWarning(context.i18n("moderation_manager.cannot_action_bot", action.getName(context.getLocale())));
             return false;
+        } else if(!submitter.canInteract(context.getGuild().getMember(target)) && context.getData().getModeration().isRespectBanOrKickHierarchy()) {
+            context.getTypedMessaging().replyWarning(context.i18n("moderation_manager.user_cannot_action_superior", action.getName(context.getLocale()), target.getName()));
+            return false;
         }
         return true;
     }

--- a/src/main/resources/lang/en-GB.json
+++ b/src/main/resources/lang/en-GB.json
@@ -1036,7 +1036,7 @@
     "missing_permission": "Cannot {0} user {1}, missing `{2}` permission!",
     "cannot_action_owner": "Cannot {0} user {1} as they are the owner of the guild!",
     "cannot_action_superior": "Cannot {0} user {1} the top role they have is higher than mine!",
-    "user_cannot_action_superior": "Cannot {0} user {1} because they are above you in the hierarchy",
+    "user_cannot_action_superior": "Cannot {0} user {1} because they are above you in the hierarchy!",
     "success": "{0} has been {1}!"
   },
   "music": {

--- a/src/main/resources/lang/en-GB.json
+++ b/src/main/resources/lang/en-GB.json
@@ -1036,6 +1036,7 @@
     "missing_permission": "Cannot {0} user {1}, missing `{2}` permission!",
     "cannot_action_owner": "Cannot {0} user {1} as they are the owner of the guild!",
     "cannot_action_superior": "Cannot {0} user {1} the top role they have is higher than mine!",
+    "user_cannot_action_superior": "Cannot {0} user {1} because they are above you in the hierarchy",
     "success": "{0} has been {1}!"
   },
   "music": {


### PR DESCRIPTION
# Pull request

 - [X] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [X] I have tested all of my changes.
 
## Added/Changed
What did you add and/or change for this.
Added a new check in ModerationManager->runChecks that checks if the submitter can interact with the target.
Added a new setting in GuildSettingsModeration for whether the hierarchy should be respected.
Added a new error message to en-GB.json for when this rule is violated.

## Bug
This was added to fix #219 
