### PR TITLE
Vote to skip feature

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
@@ -118,7 +118,7 @@ public class SkipCommand extends MainCommand {
         buttonGroup.setTimerRunTime(10);
         buttonGroup.setMaxTimeRunTime(30);
         buttonGroup.setTimerRunTimeSkipAddon(5);
-        buttonGroup.setIsMusicSkip(true);
+        buttonGroup.setIsDynamicTiming(true);
 
         for (Member member : context.getGuild().getSelfMember().getVoiceState().getChannel().getMembers()) {
             if (context.hasPermission(member, "skip")) {

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
@@ -90,6 +90,7 @@ public class SkipCommand extends MainCommand {
 
         VoteButtonGroupBuilder buttonGroupBuilder = new VoteButtonGroupBuilder(VoteMessageType.YES_NO);
         buttonGroupBuilder.addExtraButton(PersistentButton.SKIP_BUTTON_FORCE);
+        buttonGroupBuilder.setIsMusicSkip(true);
         buttonGroupBuilder.setPeriodicConsumer((results, message) -> {
             StringBuilder resultsBuilder = new StringBuilder();
             for (VoteResult result : results) {

--- a/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/music/SkipCommand.java
@@ -90,7 +90,6 @@ public class SkipCommand extends MainCommand {
 
         VoteButtonGroupBuilder buttonGroupBuilder = new VoteButtonGroupBuilder(VoteMessageType.YES_NO);
         buttonGroupBuilder.addExtraButton(PersistentButton.SKIP_BUTTON_FORCE);
-        buttonGroupBuilder.setIsMusicSkip(true);
         buttonGroupBuilder.setPeriodicConsumer((results, message) -> {
             StringBuilder resultsBuilder = new StringBuilder();
             for (VoteResult result : results) {
@@ -114,6 +113,13 @@ public class SkipCommand extends MainCommand {
             }
         });
         VoteButtonGroup buttonGroup = buttonGroupBuilder.build(sender.getIdLong(), context.getChannel().getIdLong(), context.getGuild().getIdLong());
+
+        // Specific settings for music skip
+        buttonGroup.setTimerRunTime(10);
+        buttonGroup.setMaxTimeRunTime(30);
+        buttonGroup.setTimerRunTimeSkipAddon(5);
+        buttonGroup.setIsMusicSkip(true);
+
         for (Member member : context.getGuild().getSelfMember().getVoiceState().getChannel().getMembers()) {
             if (context.hasPermission(member, "skip")) {
                 buttonGroup.allowUser(member.getIdLong());

--- a/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroup.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroup.java
@@ -142,7 +142,7 @@ public class VoteButtonGroup extends PersistentButtonGroup {
 
             int votesNeeded = (int) Math.ceil(member.getVoiceState().getChannel().getMembers().size() / 2);
 
-            if ((votes.size() - 1) >= votesNeeded) { // - 1 is because the users vote hasn't been added yet
+            if ((votes.size()) >= votesNeeded - 1) { // - 1 is because the users vote hasn't been added yet
                 CascadeBot.INS.getShardManager().getGuildById(getGuildId()).getTextChannelById(getChannelId()).retrieveMessageById(getMessageId()).queue(message -> {
                     message.delete().queue(null, DiscordUtils.handleExpectedErrors(ErrorResponse.UNKNOWN_MESSAGE));
                     voteFinished();

--- a/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroup.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroup.java
@@ -50,10 +50,10 @@ public class VoteButtonGroup extends PersistentButtonGroup {
 
     private int timerRunTimeSkipAddon;
 
-    private boolean isMusicSkip;
+    private boolean isDynamicTiming;
 
-    public void setIsMusicSkip(Boolean isMusicSkip) {
-        this.isMusicSkip = isMusicSkip;
+    public void setIsDynamicTiming(boolean isDynamicTiming) {
+        this.isDynamicTiming = isDynamicTiming;
     }
 
     public void setFinishConsumer(Consumer<List<VoteResult>> finishConsumer) {
@@ -104,16 +104,16 @@ public class VoteButtonGroup extends PersistentButtonGroup {
                 votes.remove(user.getIdLong());
                 return;
             }
-        } else if (isMusicSkip) {
-            musicSkipExtraFunctionality(user);
+        } else if (isDynamicTiming) {
+            dynamicTimingFunctionality(user);
         }
         votes.put(user.getIdLong(), vote);
     }
 
-    private void musicSkipExtraFunctionality(User user) {
+    private void dynamicTimingFunctionality(User user) {
 
         long timeElapsed = Instant.now().toEpochMilli() - timerStartTime;
-        int elapsed = (int) FormatUtils.round((timeElapsed /1000), 0);
+        int elapsed = (int) FormatUtils.round((timeElapsed / 1000.0), 0);
         int newTimersTime;
 
         if (!user.isBot() && user.getIdLong() != getOwnerId()) {
@@ -140,7 +140,7 @@ public class VoteButtonGroup extends PersistentButtonGroup {
             }
             Member member = CascadeBot.INS.getShardManager().getGuildById(getGuildId()).getMember(user);
 
-            int votesNeeded = (int) Math.ceil(member.getVoiceState().getChannel().getMembers().size() / 2);
+            int votesNeeded = (int) Math.ceil(member.getVoiceState().getChannel().getMembers().size() / 2.0);
 
             if ((votes.size()) >= votesNeeded - 1) { // - 1 is because the users vote hasn't been added yet
                 CascadeBot.INS.getShardManager().getGuildById(getGuildId()).getTextChannelById(getChannelId()).retrieveMessageById(getMessageId()).queue(message -> {

--- a/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
@@ -38,12 +38,6 @@ public class VoteButtonGroupBuilder {
 
     private BiConsumer<List<VoteResult>, Message> periodicConsumer;
 
-    private boolean isMusicSkip = false;
-
-    public void setIsMusicSkip(boolean isMusicSkip) {
-        this.isMusicSkip = isMusicSkip;
-    }
-
     /**
      * Creates a new build for {@link VoteButtonGroup}
      *
@@ -136,13 +130,6 @@ public class VoteButtonGroupBuilder {
      */
     public VoteButtonGroup build(long owner, long channelId, long guild) {
         VoteButtonGroup buttonGroup = new VoteButtonGroup(owner, channelId, guild, periodicConsumer, timer);
-        buttonGroup.setIsMusicSkip(isMusicSkip);
-        if (isMusicSkip) {
-            buttonGroup.setFinishConsumer(finishConsumer);
-            buttonGroup.setTimerRunTime(10);
-            buttonGroup.setMaxTimeRunTime(30);
-            buttonGroup.setTimerRunTimeSkipAddon(5);
-        }
         switch (type) {
             case YES_NO:
                 buttonGroup.addPersistentButton(PersistentButton.VOTE_BUTTON_YES);

--- a/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
@@ -12,6 +12,7 @@ import org.cascadebot.cascadebot.data.objects.VoteMessageType;
 import org.cascadebot.cascadebot.utils.DiscordUtils;
 import org.cascadebot.cascadebot.utils.buttons.PersistentButton;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -32,7 +33,7 @@ public class VoteButtonGroupBuilder {
     private List<Object> voteButtons = new ArrayList<>();
     private int amount = 1; //Setting this so things don't break
 
-    private long voteTime = TimeUnit.SECONDS.toMillis(30);
+    private long voteTime = TimeUnit.SECONDS.toMillis(10);
 
     private Consumer<List<VoteResult>> finishConsumer;
 
@@ -129,7 +130,7 @@ public class VoteButtonGroupBuilder {
      * @return a {@link VoteButtonGroup}.
      */
     public VoteButtonGroup build(long owner, long channelId, long guild) {
-        VoteButtonGroup buttonGroup = new VoteButtonGroup(owner, channelId, guild, periodicConsumer, timer);
+        VoteButtonGroup buttonGroup = new VoteButtonGroup(owner, channelId, guild, periodicConsumer, timer, Instant.now().toEpochMilli(), finishConsumer);
         switch (type) {
             case YES_NO:
                 buttonGroup.addPersistentButton(PersistentButton.VOTE_BUTTON_YES);
@@ -169,5 +170,4 @@ public class VoteButtonGroupBuilder {
 
         return buttonGroup;
     }
-
 }

--- a/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/votes/VoteButtonGroupBuilder.java
@@ -12,7 +12,6 @@ import org.cascadebot.cascadebot.data.objects.VoteMessageType;
 import org.cascadebot.cascadebot.utils.DiscordUtils;
 import org.cascadebot.cascadebot.utils.buttons.PersistentButton;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -38,6 +37,12 @@ public class VoteButtonGroupBuilder {
     private Consumer<List<VoteResult>> finishConsumer;
 
     private BiConsumer<List<VoteResult>, Message> periodicConsumer;
+
+    private boolean isMusicSkip = false;
+
+    public void setIsMusicSkip(boolean isMusicSkip) {
+        this.isMusicSkip = isMusicSkip;
+    }
 
     /**
      * Creates a new build for {@link VoteButtonGroup}
@@ -130,7 +135,14 @@ public class VoteButtonGroupBuilder {
      * @return a {@link VoteButtonGroup}.
      */
     public VoteButtonGroup build(long owner, long channelId, long guild) {
-        VoteButtonGroup buttonGroup = new VoteButtonGroup(owner, channelId, guild, periodicConsumer, timer, Instant.now().toEpochMilli(), finishConsumer);
+        VoteButtonGroup buttonGroup = new VoteButtonGroup(owner, channelId, guild, periodicConsumer, timer);
+        buttonGroup.setIsMusicSkip(isMusicSkip);
+        if (isMusicSkip) {
+            buttonGroup.setFinishConsumer(finishConsumer);
+            buttonGroup.setTimerRunTime(10);
+            buttonGroup.setMaxTimeRunTime(30);
+            buttonGroup.setTimerRunTimeSkipAddon(5);
+        }
         switch (type) {
             case YES_NO:
                 buttonGroup.addPersistentButton(PersistentButton.VOTE_BUTTON_YES);


### PR DESCRIPTION
Added functionality where vote to skip timer starts at 10 seconds and increases by 5 seconds everytime a new member votes, with a max of 30 seconds.

Also if at least 50% of the voice channel vote it will skip straight away.

# Pull request

 - [X] I have read and agreed to the [code of conduct](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/CascadeBot/CascadeBot/blob/master/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me or was not being worked on and is a somewhat requested feature. For reference see our [GitHub projects](https://github.com/orgs/CascadeBot/projects).
 - [X] I have tested all of my changes.
 
## Added/Changed
What did you add and/or change for this.
Changes to the VoteButtonGroup and VoteButtonGroupBuilder in side the utils/votes package.

## Feature
#221 
