### PR TITLE
Guild Data

### DIFF
--- a/src/main/java/org/cascadebot/cascadebot/commands/management/module/ModuleDisableSubCommand.java
+++ b/src/main/java/org/cascadebot/cascadebot/commands/management/module/ModuleDisableSubCommand.java
@@ -33,19 +33,17 @@ public class ModuleDisableSubCommand extends SubCommand {
         if (module != null) {
             String moduleName = ExtensionsKt.toCapitalized(FormatUtils.formatEnum(module, context.getLocale()));
             try {
-                context.getData().write(guildData -> {
-                    if (guildData.getCore().disableModule(module)) {
-                        // If module wasn't already disabled
-                        context.getTypedMessaging().replySuccess(context.i18n("commands.module.disable.disabled", moduleName));
-                        ModlogEvent event = ModlogEvent.CASCADE_MODULE_UPDATED;
-                        ModlogEventData eventStore = new ModlogEventData(event, sender.getUser(), module, List.of());
-                        eventStore.setExtraDescriptionInfo(List.of("false"));
-                        context.getData().getModeration().sendModlogEvent(context.getGuild().getIdLong(), eventStore);
-                    } else {
-                        // If module was already disabled
-                        context.getTypedMessaging().replyInfo(context.i18n("commands.module.disable.already_disabled", moduleName));
-                    }
-                });
+                if (context.getData().writeInline(data -> data.getCore().disableModule(module))) {
+                    // If module wasn't already disabled
+                    context.getTypedMessaging().replySuccess(context.i18n("commands.module.disable.disabled", moduleName));
+                    ModlogEvent event = ModlogEvent.CASCADE_MODULE_UPDATED;
+                    ModlogEventData eventStore = new ModlogEventData(event, sender.getUser(), module, List.of());
+                    eventStore.setExtraDescriptionInfo(List.of("false"));
+                    context.getData().getModeration().sendModlogEvent(context.getGuild().getIdLong(), eventStore);
+                } else {
+                    // If module was already disabled
+                    context.getTypedMessaging().replyInfo(context.i18n("commands.module.disable.already_disabled", moduleName));
+                }
             } catch (IllegalArgumentException ex) {
                 context.getTypedMessaging().replyDanger(ex.getMessage());
             }

--- a/src/main/java/org/cascadebot/cascadebot/utils/GuildDataUtils.java
+++ b/src/main/java/org/cascadebot/cascadebot/utils/GuildDataUtils.java
@@ -1,15 +1,12 @@
 package org.cascadebot.cascadebot.utils;
 
+import org.cascadebot.cascadebot.data.objects.GuildData;
 import org.slf4j.MDC;
 
 public class GuildDataUtils {
 
     public static void assertWriteMode() {
-        String mode = MDC.get("writeMode");
-        if (mode == null) {
-            throw new UnsupportedOperationException("Cannot write guild data if not in write mode!");
-        }
-        boolean writeMode = Boolean.parseBoolean(mode);
+        boolean writeMode = GuildData.Companion.getWriteMode().get();
         if (!writeMode) {
             throw new UnsupportedOperationException("Cannot write guild data if not in write mode!");
         }

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
@@ -162,10 +162,6 @@ class GuildData(@field:Id val guildId: Long): Cloneable {
         }
     }
 
-    fun write(writer: (GuildData) -> Unit) {
-        write(Consumer(writer))
-    }
-
     fun <T : Any?> writeInline(writer: Function<GuildData, T>) : T {
         this.lock.writeLock().withLock {
             val copy: GuildData = CascadeBot.getGSON().fromJson(CascadeBot.getGSON().toJson(this), this.javaClass)
@@ -177,10 +173,6 @@ class GuildData(@field:Id val guildId: Long): Cloneable {
             //println(GsonBuilder().setPrettyPrinting().create().toJson(diff))
             return output
         }
-    }
-
-    fun <T: Any?> writeInline(writer: (GuildData)->T) : T {
-        return writeInline(Function(writer))
     }
 
 }

--- a/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/data/objects/GuildData.kt
@@ -162,6 +162,10 @@ class GuildData(@field:Id val guildId: Long): Cloneable {
         }
     }
 
+    fun write(writer: (GuildData) -> Unit) {
+        write(Consumer(writer))
+    }
+
     fun <T : Any?> writeInline(writer: Function<GuildData, T>) : T {
         this.lock.writeLock().withLock {
             val copy: GuildData = CascadeBot.getGSON().fromJson(CascadeBot.getGSON().toJson(this), this.javaClass)
@@ -173,6 +177,10 @@ class GuildData(@field:Id val guildId: Long): Cloneable {
             //println(GsonBuilder().setPrettyPrinting().create().toJson(diff))
             return output
         }
+    }
+
+    fun <T: Any?> writeInline(writer: (GuildData)->T) : T {
+        return writeInline(Function(writer))
     }
 
 }

--- a/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
@@ -11,6 +11,7 @@ import org.cascadebot.cascadebot.commands.music.SkipCommand
 import org.cascadebot.cascadebot.data.managers.GuildDataManager
 import org.cascadebot.cascadebot.utils.DiscordUtils
 import org.cascadebot.cascadebot.utils.votes.VoteButtonGroup
+import java.util.function.Consumer
 
 enum class PersistentButton(@field:Transient val button: Button) {
     TODO_BUTTON_CHECK(
@@ -18,7 +19,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
             UnicodeConstants.TICK,
             IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
                 GuildDataManager.getGuildData(channel.guild.idLong)
-                    .write {
+                    .write(Consumer {
                         val todoList =
                             it.useful.getTodoListByMessage(message.idLong)
                         if (todoList.canUserEdit(runner.idLong)) {
@@ -27,14 +28,14 @@ enum class PersistentButton(@field:Transient val button: Button) {
                             todoList.addUncheckButton(message)
                             message.editMessage(todoList.todoListMessage).queue()
                         }
-                    }
+                    })
             })
     ),
     TODO_BUTTON_UNCHECK(
         Button.UnicodeButton(
             UnicodeConstants.WHITE_HALLOW_SQUARE,
             IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-                GuildDataManager.getGuildData(channel.guild.idLong).write {
+                GuildDataManager.getGuildData(channel.guild.idLong).write(Consumer {
                     val todoList =
                         it.useful.getTodoListByMessage(message.idLong)
                     if (todoList.canUserEdit(runner.idLong)) {
@@ -43,7 +44,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
                         todoList.addCheckButton(message)
                         message.editMessage(todoList.todoListMessage).queue()
                     }
-                }
+                })
             })
     ),
     TODO_BUTTON_NAVIGATE_LEFT(

--- a/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
+++ b/src/main/kotlin/org/cascadebot/cascadebot/utils/buttons/PersistentButton.kt
@@ -11,7 +11,6 @@ import org.cascadebot.cascadebot.commands.music.SkipCommand
 import org.cascadebot.cascadebot.data.managers.GuildDataManager
 import org.cascadebot.cascadebot.utils.DiscordUtils
 import org.cascadebot.cascadebot.utils.votes.VoteButtonGroup
-import java.util.function.Consumer
 
 enum class PersistentButton(@field:Transient val button: Button) {
     TODO_BUTTON_CHECK(
@@ -19,7 +18,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
             UnicodeConstants.TICK,
             IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
                 GuildDataManager.getGuildData(channel.guild.idLong)
-                    .write(Consumer {
+                    .write {
                         val todoList =
                             it.useful.getTodoListByMessage(message.idLong)
                         if (todoList.canUserEdit(runner.idLong)) {
@@ -28,14 +27,14 @@ enum class PersistentButton(@field:Transient val button: Button) {
                             todoList.addUncheckButton(message)
                             message.editMessage(todoList.todoListMessage).queue()
                         }
-                    })
+                    }
             })
     ),
     TODO_BUTTON_UNCHECK(
         Button.UnicodeButton(
             UnicodeConstants.WHITE_HALLOW_SQUARE,
             IButtonRunnable { runner: Member, channel: TextChannel, message: Message ->
-                GuildDataManager.getGuildData(channel.guild.idLong).write(Consumer {
+                GuildDataManager.getGuildData(channel.guild.idLong).write {
                     val todoList =
                         it.useful.getTodoListByMessage(message.idLong)
                     if (todoList.canUserEdit(runner.idLong)) {
@@ -44,7 +43,7 @@ enum class PersistentButton(@field:Transient val button: Button) {
                         todoList.addCheckButton(message)
                         message.editMessage(todoList.todoListMessage).queue()
                     }
-                })
+                }
             })
     ),
     TODO_BUTTON_NAVIGATE_LEFT(


### PR DESCRIPTION
 - Introduce "inline write" to avoid having to wrap huge blocks of text
 - Instead of using MDC, use our own threadlocal on the GuildData companion object